### PR TITLE
BUGFIX: add currency to amount when completing purchase.

### DIFF
--- a/code/services/PurchaseService.php
+++ b/code/services/PurchaseService.php
@@ -90,7 +90,8 @@ class PurchaseService extends PaymentService{
 	public function completePurchase() {
 		$gatewayresponse = $this->createGatewayResponse();
 		$request = $this->oGateway()->completePurchase(array(
-			'amount' => (float) $this->payment->MoneyAmount
+			'amount' => (float) $this->payment->MoneyAmount,
+			'currency' => $this->payment->MoneyCurrency
 		));
 		$this->createMessage('CompletePurchaseRequest', $request);
 		$response = null;


### PR DESCRIPTION
Amount and currency always come in a pair when you work with Money.  We are adding currency here with amount to prevent Paypal from throwing an error when submitting a non-USD payment.
