### PR TITLE
Void on failure fix

### DIFF
--- a/code/services/PurchaseService.php
+++ b/code/services/PurchaseService.php
@@ -103,12 +103,13 @@ class PurchaseService extends PaymentService{
 			if ($response->isSuccessful()) {
 				$this->createMessage('PurchasedResponse', $response);
 				$this->payment->Status = 'Captured';
+				$this->payment->write();
 				$this->payment->extend('onCaptured', $gatewayresponse);
 			} else {
 				$this->createMessage('CompletePurchaseError', $response);
 				$this->payment->Status = 'Void';
+				$this->payment->write();
 			}
-			$this->payment->write();
 		} catch (Omnipay\Common\Exception\OmnipayException $e) {
 			$this->createMessage("CompletePurchaseError", $e);
 		}


### PR DESCRIPTION
Regression from 964fb1489ea912d9ce330632b235ceab519d5695

This breaks onCaptured, since it checks for `TotalOutstanding` via `Payable->TotalPaid()`, which in turn uses `the Order->Payments()` relationship. Since `Status=Captured` isn't written at this point, the result is `>0`, failing the order.
