### PR TITLE
UNFINISHED: saved cards

### DIFF
--- a/code/model/GatewayInfo.php
+++ b/code/model/GatewayInfo.php
@@ -87,6 +87,16 @@ class GatewayInfo{
         return in_array($gateway,$manualGateways);
     }
 
+    /**
+     * @param string $gateway - gateway name
+     * @return boolean - can the gateway save cards or not
+     */
+    public static function can_save_cards($gateway) {
+        $factory = new GatewayFactory;
+        $gateway = $factory->create($gateway);
+        return $gateway->supportsCreateCard(); // we don't check for update & delete b/c not all support them
+    }
+
 	/**
 	 * Get the required parameters for a given gateway
 	 * @param string $gateway gateway name

--- a/code/model/Payment.php
+++ b/code/model/Payment.php
@@ -6,6 +6,12 @@
  * This class is used for storing a payment amount, and it's status of being
  * paid or not, and the gateway used to make payment.
  *
+ * @property string Gateway
+ * @property Money Money
+ * @property string Status
+ * @method SavedCard SavedCard()
+ * @method HasManyList Messages()
+ *
  * @package payment
  */
 final class Payment extends DataObject{
@@ -16,6 +22,10 @@ final class Payment extends DataObject{
 		'Status' => "Enum('Created,Authorized,Captured,Refunded,Void','Created')",
 		'Identifier' => 'Varchar'
 	);
+
+    private static $has_one = array(
+        'SavedCard' => 'SavedCard',
+    );
 
 	private static $has_many = array(
 		'Messages' => 'PaymentMessage'

--- a/code/model/Payment.php
+++ b/code/model/Payment.php
@@ -9,7 +9,7 @@
  * @property string Gateway
  * @property Money Money
  * @property string Status
- * @method SavedCard SavedCard()
+ * @method SavedCreditCard SavedCreditCard()
  * @method HasManyList Messages()
  *
  * @package payment
@@ -24,7 +24,7 @@ final class Payment extends DataObject{
 	);
 
     private static $has_one = array(
-        'SavedCard' => 'SavedCard',
+        'SavedCreditCard' => 'SavedCreditCard',
     );
 
 	private static $has_many = array(

--- a/code/model/SavedCard.php
+++ b/code/model/SavedCard.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Stores information about a saved credit card. Only
+ * used for gateways that support createCard.
+ *
+ * @property string CardReference - returned from gateway
+ * @property string LastFourDigits - truncated credit card number
+ * @property string Name - optional name of the card for user's use
+ * @property int UserID
+ * @method Member User()
+ * @method HasManyList Payments()
+ *
+ * @package omnipay
+ */
+class SavedCard extends DataObject {
+
+    private static $db = array(
+        'CardReference' => 'Varchar(255)',
+        'LastFourDigits' => 'Varchar(10)',
+        'Name' => 'Varchar(255)', // optional
+    );
+
+    private static $has_one = array(
+        'User' => 'Member', // optional
+    );
+
+    private static $has_many = array(
+        'Payments' => 'Payment',
+    );
+
+}

--- a/code/model/SavedCreditCard.php
+++ b/code/model/SavedCreditCard.php
@@ -13,7 +13,7 @@
  *
  * @package omnipay
  */
-class SavedCard extends DataObject {
+class SavedCreditCard extends DataObject {
 
     private static $db = array(
         'CardReference' => 'Varchar(255)',

--- a/code/model/messaging/CreateCardError.php
+++ b/code/model/messaging/CreateCardError.php
@@ -1,0 +1,4 @@
+<?php
+class CreateCardError extends GatewayErrorMessage {
+
+}

--- a/code/model/messaging/CreateCardRequest.php
+++ b/code/model/messaging/CreateCardRequest.php
@@ -1,0 +1,3 @@
+<?php
+class CreateCardRequest extends GatewayResponseMessage{
+}

--- a/code/model/messaging/CreateCardResponse.php
+++ b/code/model/messaging/CreateCardResponse.php
@@ -1,0 +1,3 @@
+<?php
+class CreateCardResponse extends GatewayResponseMessage{
+}

--- a/code/model/messaging/DeleteCardRequest.php
+++ b/code/model/messaging/DeleteCardRequest.php
@@ -1,0 +1,3 @@
+<?php
+class DeleteCardRequest extends GatewayResponseMessage{
+}

--- a/code/model/messaging/DeleteCardResponse.php
+++ b/code/model/messaging/DeleteCardResponse.php
@@ -1,0 +1,3 @@
+<?php
+class DeleteCardResponse extends GatewayResponseMessage{
+}

--- a/code/model/messaging/UpdateCardRequest.php
+++ b/code/model/messaging/UpdateCardRequest.php
@@ -1,0 +1,3 @@
+<?php
+class UpdateCardRequest extends GatewayResponseMessage{
+}

--- a/code/model/messaging/UpdateCardResponse.php
+++ b/code/model/messaging/UpdateCardResponse.php
@@ -1,0 +1,3 @@
+<?php
+class UpdateCardResponse extends GatewayResponseMessage{
+}

--- a/code/services/PurchaseService.php
+++ b/code/services/PurchaseService.php
@@ -24,7 +24,7 @@ class PurchaseService extends PaymentService{
 		}
 
 		// Are we using a tokenized card?
-		$savedCard = $this->payment->SavedCard();
+		$savedCard = $this->payment->SavedCreditCard();
 
 		//update success/fail urls
 		$this->update($data);

--- a/code/services/PurchaseService.php
+++ b/code/services/PurchaseService.php
@@ -22,6 +22,10 @@ class PurchaseService extends PaymentService{
 		if (!$this->payment->isInDB()) {
 			$this->payment->write();
 		}
+
+		// Are we using a tokenized card?
+		$savedCard = $this->payment->SavedCard();
+
 		//update success/fail urls
 		$this->update($data);
 
@@ -32,6 +36,7 @@ class PurchaseService extends PaymentService{
 
 		$gatewaydata = array_merge($data,array(
 			'card' => $this->getCreditCard($data),
+			'cardReference' => $savedCard && $savedCard->exists() ? $savedCard->CardReference : null,
 			'amount' => (float) $this->payment->MoneyAmount,
 			'currency' => $this->payment->MoneyCurrency,
 			//set all gateway return/cancel/notify urls to PaymentGatewayController endpoint

--- a/code/services/SavedCardService.php
+++ b/code/services/SavedCardService.php
@@ -1,0 +1,108 @@
+<?php
+use Omnipay\Common\CreditCard;
+
+/**
+ * Wrapper for create/update/deleteCard methods on omnipay gateway.
+ *
+ * @package omnipay
+ */
+class SavedCardService extends PaymentService {
+
+    /**
+     * Attempt to save a new credit card.
+     *
+     * @param  array $data returnUrl/cancelUrl + customer creditcard and billing/shipping details.
+     * 	Some keys (e.g. "amount") are overwritten with data from the associated {@link $payment}.
+     *  If this array is constructed from user data (e.g. a form submission), please take care
+     *  to whitelist accepted fields, in order to ensure sensitive gateway parameters like "freeShipping" can't be set.
+     *  If using {@link Form->getData()}, only fields which exist in the form are returned,
+     *  effectively whitelisting against arbitrary user input.
+     * @return ResponseInterface omnipay's response class, specific to the chosen gateway.
+     */
+    public function createCard($data = array()) {
+        if ($this->payment->Status !== "Created") {
+            return null; //could be handled better? send payment response?
+        }
+        if (!$this->payment->isInDB()) {
+            $this->payment->write();
+        }
+
+        // if they didn't give us a name, create one from the masked number
+        if (empty($data['name'])) {
+            $data['name'] = preg_replace('/[^0-9]/', '', $data['number']);               // normalize out dashes and spaced
+            $data['name'] = preg_replace('/[0-9]/', '*', $data['name']);                 // replace numbers
+            $data['name'] = substr($data['name'], 0, -4) . substr($data['number'], -4);  // swap in the last 4 digits
+        }
+
+        $message = $this->createMessage('CreateCardRequest');
+        $message->write();
+
+        $request = $this->oGateway()->createCard(array_merge(
+            $data,
+            array(
+                'card' => $this->getCreditCard($data),
+                'clientIp' => isset($data['clientIp']) ? $data['clientIp'] : null,
+            )
+        ));
+        $this->logToFile($request->getParameters(), "CreateCardRequest_post");
+
+        $gatewayresponse = $this->createGatewayResponse();
+        try {
+            $response = $this->response = $request->send();
+            $gatewayresponse->setOmnipayResponse($response);
+
+            //update payment model
+            if ($response->isSuccessful()) {
+                //successful payment
+                $this->createMessage('CreateCardResponse', $response);
+                $gatewayresponse->setMessage("Card created successfully");
+
+                // create the saved card
+                $card = new SavedCard(array(
+                    'CardReference' => $response->getCardReference(),
+                    'LastFourDigits' => substr($data['number'], -4),
+                    'Name' => $data['name'],
+                    'UserID' => Member::currentUserID(),
+                ));
+
+                $card->write();
+
+                $this->payment->SavedCardID = $card->ID;
+                $this->payment->write();
+            } else {
+                //handle error
+                $this->createMessage('CreateCardError', $response);
+                $gatewayresponse->setMessage(
+                    "Error (".$response->getCode()."): ".$response->getMessage()
+                );
+            }
+        } catch (Omnipay\Common\Exception\OmnipayException $e) {
+            $this->createMessage('CreateCardError', $e);
+            $gatewayresponse->setMessage($e->getMessage());
+        }
+
+        // not sure if this is needed
+        $gatewayresponse->setRedirectURL($this->getRedirectURL());
+
+        return $gatewayresponse;
+    }
+
+
+    public function updateCard(SavedCard $card, $data = array()) {
+        // TODO
+    }
+
+    public function deleteCard(SavedCard $card) {
+        // TODO
+    }
+
+    /**
+     * @param array $data
+     * @return \Omnipay\Common\CreditCard
+     */
+    protected function getCreditCard($data) {
+        return new CreditCard($data);
+    }
+
+
+}

--- a/code/services/SavedCardService.php
+++ b/code/services/SavedCardService.php
@@ -11,13 +11,8 @@ class SavedCardService extends PaymentService {
     /**
      * Attempt to save a new credit card.
      *
-     * @param  array $data returnUrl/cancelUrl + customer creditcard and billing/shipping details.
-     * 	Some keys (e.g. "amount") are overwritten with data from the associated {@link $payment}.
-     *  If this array is constructed from user data (e.g. a form submission), please take care
-     *  to whitelist accepted fields, in order to ensure sensitive gateway parameters like "freeShipping" can't be set.
-     *  If using {@link Form->getData()}, only fields which exist in the form are returned,
-     *  effectively whitelisting against arbitrary user input.
-     * @return ResponseInterface omnipay's response class, specific to the chosen gateway.
+     * @param  array $data
+     * @return \Omnipay\Common\Message\ResponseInterface omnipay's response class, specific to the chosen gateway.
      */
     public function createCard($data = array()) {
         if ($this->payment->Status !== "Created") {
@@ -86,7 +81,6 @@ class SavedCardService extends PaymentService {
 
         return $gatewayresponse;
     }
-
 
     public function updateCard(SavedCreditCard $card, $data = array()) {
         // TODO

--- a/code/services/SavedCardService.php
+++ b/code/services/SavedCardService.php
@@ -58,7 +58,7 @@ class SavedCardService extends PaymentService {
                 $gatewayresponse->setMessage("Card created successfully");
 
                 // create the saved card
-                $card = new SavedCard(array(
+                $card = new SavedCreditCard(array(
                     'CardReference' => $response->getCardReference(),
                     'LastFourDigits' => substr($data['number'], -4),
                     'Name' => $data['name'],
@@ -88,11 +88,11 @@ class SavedCardService extends PaymentService {
     }
 
 
-    public function updateCard(SavedCard $card, $data = array()) {
+    public function updateCard(SavedCreditCard $card, $data = array()) {
         // TODO
     }
 
-    public function deleteCard(SavedCard $card) {
+    public function deleteCard(SavedCreditCard $card) {
         // TODO
     }
 

--- a/code/services/SavedCardService.php
+++ b/code/services/SavedCardService.php
@@ -8,95 +8,95 @@ use Omnipay\Common\CreditCard;
  */
 class SavedCardService extends PaymentService {
 
-    /**
-     * Attempt to save a new credit card.
-     *
-     * @param  array $data
-     * @return \Omnipay\Common\Message\ResponseInterface omnipay's response class, specific to the chosen gateway.
-     */
-    public function createCard($data = array()) {
-        if ($this->payment->Status !== "Created") {
-            return null; //could be handled better? send payment response?
-        }
-        if (!$this->payment->isInDB()) {
-            $this->payment->write();
-        }
+	/**
+	 * Attempt to save a new credit card.
+	 *
+	 * @param  array $data
+	 * @return \Omnipay\Common\Message\ResponseInterface omnipay's response class, specific to the chosen gateway.
+	 */
+	public function createCard($data = array()) {
+		if ($this->payment->Status !== "Created") {
+			return null; //could be handled better? send payment response?
+		}
+		if (!$this->payment->isInDB()) {
+			$this->payment->write();
+		}
 
-        // if they didn't give us a name, create one from the masked number
-        if (empty($data['name'])) {
-            $data['name'] = preg_replace('/[^0-9]/', '', $data['number']);               // normalize out dashes and spaced
-            $data['name'] = preg_replace('/[0-9]/', '*', $data['name']);                 // replace numbers
-            $data['name'] = substr($data['name'], 0, -4) . substr($data['number'], -4);  // swap in the last 4 digits
-        }
+		// if they didn't give us a name, create one from the masked number
+		if (empty($data['cardName'])) {
+			$data['cardName'] = preg_replace('/[^0-9]/', '', $data['number']);               // normalize out dashes and spaced
+			$data['cardName'] = preg_replace('/[0-9]/', '*', $data['cardName']);                 // replace numbers
+			$data['cardName'] = substr($data['cardName'], 0, -4) . substr($data['number'], -4);  // swap in the last 4 digits
+		}
 
-        $message = $this->createMessage('CreateCardRequest');
-        $message->write();
+		$message = $this->createMessage('CreateCardRequest');
+		$message->write();
 
-        $request = $this->oGateway()->createCard(array_merge(
-            $data,
-            array(
-                'card' => $this->getCreditCard($data),
-                'clientIp' => isset($data['clientIp']) ? $data['clientIp'] : null,
-            )
-        ));
-        $this->logToFile($request->getParameters(), "CreateCardRequest_post");
+		$request = $this->oGateway()->createCard(array_merge(
+			$data,
+			array(
+				'card' => $this->getCreditCard($data),
+				'clientIp' => isset($data['clientIp']) ? $data['clientIp'] : null,
+			)
+		));
+		$this->logToFile($request->getParameters(), "CreateCardRequest_post");
 
-        $gatewayresponse = $this->createGatewayResponse();
-        try {
-            $response = $this->response = $request->send();
-            $gatewayresponse->setOmnipayResponse($response);
+		$gatewayresponse = $this->createGatewayResponse();
+		try {
+			$response = $this->response = $request->send();
+			$gatewayresponse->setOmnipayResponse($response);
 
-            //update payment model
-            if ($response->isSuccessful()) {
-                //successful payment
-                $this->createMessage('CreateCardResponse', $response);
-                $gatewayresponse->setMessage("Card created successfully");
+			//update payment model
+			if ($response->isSuccessful()) {
+				//successful payment
+				$this->createMessage('CreateCardResponse', $response);
+				$gatewayresponse->setMessage("Card created successfully");
 
-                // create the saved card
-                $card = new SavedCreditCard(array(
-                    'CardReference' => $response->getCardReference(),
-                    'LastFourDigits' => substr($data['number'], -4),
-                    'Name' => $data['name'],
-                    'UserID' => Member::currentUserID(),
-                ));
+				// create the saved card
+				$card = new SavedCreditCard(array(
+					'CardReference'  => $response->getCardReference(),
+					'LastFourDigits' => substr($data['number'], -4),
+					'Name'           => $data['cardName'],
+					'UserID'         => Member::currentUserID(),
+				));
 
-                $card->write();
+				$card->write();
 
-                $this->payment->SavedCardID = $card->ID;
-                $this->payment->write();
-            } else {
-                //handle error
-                $this->createMessage('CreateCardError', $response);
-                $gatewayresponse->setMessage(
-                    "Error (".$response->getCode()."): ".$response->getMessage()
-                );
-            }
-        } catch (Omnipay\Common\Exception\OmnipayException $e) {
-            $this->createMessage('CreateCardError', $e);
-            $gatewayresponse->setMessage($e->getMessage());
-        }
+				$this->payment->SavedCreditCardID = $card->ID;
+				$this->payment->write();
+			} else {
+				//handle error
+				$this->createMessage('CreateCardError', $response);
+				$gatewayresponse->setMessage(
+					"Error (".$response->getCode()."): ".$response->getMessage()
+				);
+			}
+		} catch (Omnipay\Common\Exception\OmnipayException $e) {
+			$this->createMessage('CreateCardError', $e);
+			$gatewayresponse->setMessage($e->getMessage());
+		}
 
-        // not sure if this is needed
-        $gatewayresponse->setRedirectURL($this->getRedirectURL());
+		// not sure if this is needed
+		$gatewayresponse->setRedirectURL($this->getRedirectURL());
 
-        return $gatewayresponse;
-    }
+		return $gatewayresponse;
+	}
 
-    public function updateCard(SavedCreditCard $card, $data = array()) {
-        // TODO
-    }
+	public function updateCard(SavedCreditCard $card, $data = array()) {
+		// TODO
+	}
 
-    public function deleteCard(SavedCreditCard $card) {
-        // TODO
-    }
+	public function deleteCard(SavedCreditCard $card) {
+		// TODO
+	}
 
-    /**
-     * @param array $data
-     * @return \Omnipay\Common\CreditCard
-     */
-    protected function getCreditCard($data) {
-        return new CreditCard($data);
-    }
+	/**
+	 * @param array $data
+	 * @return \Omnipay\Common\CreditCard
+	 */
+	protected function getCreditCard($data) {
+		return new CreditCard($data);
+	}
 
 
 }

--- a/tests/SavedCardServiceTest.php
+++ b/tests/SavedCardServiceTest.php
@@ -16,10 +16,10 @@ class SavedCardServiceTest extends PaymentTest {
         $this->assertFalse($response->isRedirect());
         $this->assertSame("Created", $payment->Status, 'does not process payment');
 
-        /** @var SavedCard $card */
+        /** @var SavedCreditCard $card */
         $card = $payment->SavedCard();
         $this->assertNotNull($card);
-        $this->assertInstanceOf('SavedCard', $card);
+        $this->assertInstanceOf('SavedCreditCard', $card);
         $this->assertEquals('My Test Card 1', $card->Name);
         $this->assertEquals('1111', $card->LastFourDigits);
         $this->assertEquals('cus_1MZSEtqSghKx99', $card->CardReference);
@@ -42,7 +42,7 @@ class SavedCardServiceTest extends PaymentTest {
         ));
         $this->assertTrue($response->isSuccessful());
 
-        /** @var SavedCard $card */
+        /** @var SavedCreditCard $card */
         $card = $payment->SavedCard();
         $this->assertEquals('************1111', $card->Name);
         $this->assertEquals('1111', $card->LastFourDigits);

--- a/tests/SavedCardServiceTest.php
+++ b/tests/SavedCardServiceTest.php
@@ -2,97 +2,97 @@
 
 class SavedCardServiceTest extends PaymentTest {
 
-    public function testCreateCard() {
-        $payment = $this->payment->setGateway('Stripe');
-        $service = new SavedCardService($payment);
-        $this->setMockHttpResponse('Stripe/Mock/CreateCardSuccess.txt');
-        $response = $service->createCard(array(
-            'name' => 'My Test Card 1',
-            'number' => '4111111111111111',
-            'expiryMonth' => '5',
-            'expiryYear' => date("Y", strtotime("+1 year"))
-        ));
-        $this->assertTrue($response->isSuccessful());
-        $this->assertFalse($response->isRedirect());
-        $this->assertSame("Created", $payment->Status, 'does not process payment');
+	public function testCreateCard() {
+		$payment = $this->payment->setGateway('Stripe');
+		$service = new SavedCardService($payment);
+		$this->setMockHttpResponse('Stripe/Mock/CreateCardSuccess.txt');
+		$response = $service->createCard(array(
+			'cardName' => 'My Test Card 1',
+			'number' => '4111111111111111',
+			'expiryMonth' => '5',
+			'expiryYear' => date("Y", strtotime("+1 year"))
+		));
+		$this->assertTrue($response->isSuccessful());
+		$this->assertFalse($response->isRedirect());
+		$this->assertSame("Created", $payment->Status, 'does not process payment');
 
-        /** @var SavedCreditCard $card */
-        $card = $payment->SavedCreditCard();
-	    Debug::dump($card);
-        $this->assertNotNull($card);
-        $this->assertInstanceOf('SavedCreditCard', $card);
-        $this->assertEquals('My Test Card 1', $card->Name);
-        $this->assertEquals('1111', $card->LastFourDigits);
-        $this->assertEquals('cus_1MZSEtqSghKx99', $card->CardReference);
+		/** @var SavedCreditCard $card */
+		$card = $payment->SavedCreditCard();
+		Debug::dump($card);
+		$this->assertNotNull($card);
+		$this->assertInstanceOf('SavedCreditCard', $card);
+		$this->assertEquals('My Test Card 1', $card->Name);
+		$this->assertEquals('1111', $card->LastFourDigits);
+		$this->assertEquals('cus_1MZSEtqSghKx99', $card->CardReference);
 
-        //check messaging
-        $this->assertDOSContains(array(
-            array('ClassName' => 'CreateCardRequest'),
-            array('ClassName' => 'CreateCardResponse'),
-        ), $payment->Messages());
-    }
+		//check messaging
+		$this->assertDOSContains(array(
+			array('ClassName' => 'CreateCardRequest'),
+			array('ClassName' => 'CreateCardResponse'),
+		), $payment->Messages());
+	}
 
-    public function testCreateCardWithNoName() {
-        $payment = $this->payment->setGateway('Stripe');
-        $service = new SavedCardService($payment);
-        $this->setMockHttpResponse('Stripe/Mock/CreateCardSuccess.txt');
-        $response = $service->createCard(array(
-            'number' => '4111-1111-1111-1111',
-            'expiryMonth' => '5',
-            'expiryYear' => date("Y", strtotime("+1 year"))
-        ));
-        $this->assertTrue($response->isSuccessful());
+	public function testCreateCardWithNoName() {
+		$payment = $this->payment->setGateway('Stripe');
+		$service = new SavedCardService($payment);
+		$this->setMockHttpResponse('Stripe/Mock/CreateCardSuccess.txt');
+		$response = $service->createCard(array(
+			'number' => '4111-1111-1111-1111',
+			'expiryMonth' => '5',
+			'expiryYear' => date("Y", strtotime("+1 year"))
+		));
+		$this->assertTrue($response->isSuccessful());
 
-        /** @var SavedCreditCard $card */
-        $card = $payment->SavedCreditCard();
-        $this->assertEquals('************1111', $card->Name);
-        $this->assertEquals('1111', $card->LastFourDigits);
-    }
+		/** @var SavedCreditCard $card */
+		$card = $payment->SavedCreditCard();
+		$this->assertEquals('************1111', $card->Name);
+		$this->assertEquals('1111', $card->LastFourDigits);
+	}
 
-    public function testUpdateCard() {
-        $this->markTestIncomplete('Need to test/implement updateCard');
-    }
+	public function testUpdateCard() {
+		$this->markTestIncomplete('Need to test/implement updateCard');
+	}
 
-    public function testDeleteCard() {
-        $this->markTestIncomplete('Need to test/implement deleteCard');
-    }
+	public function testDeleteCard() {
+		$this->markTestIncomplete('Need to test/implement deleteCard');
+	}
 
-    public function testPayWithCard() {
-        $card = $this->getTestPaymentWithSavedCard()->SavedCreditCard();
-        $payment = $this->payment->setGateway('Stripe');
-        $payment->setAmount(10.00);
-        $payment->setCurrency('NZD');
-        $payment->SavedCardID = $card->ID;
-        $payment->write();
-        $service = new PurchaseService($payment);
-        $this->setMockHttpResponse('Stripe/Mock/PurchaseSuccess.txt');//add success mock response from file
-        $response = $service->purchase();
-        $this->assertTrue($response->isSuccessful());
-        $this->assertFalse($response->isRedirect());
-        $this->assertSame("Captured", $payment->Status, "has the payment been captured");
+	public function testPayWithCard() {
+		$card = $this->getTestPaymentWithSavedCard()->SavedCreditCard();
+		$payment = $this->payment->setGateway('Stripe');
+		$payment->setAmount(10.00);
+		$payment->setCurrency('NZD');
+		$payment->SavedCardID = $card->ID;
+		$payment->write();
+		$service = new PurchaseService($payment);
+		$this->setMockHttpResponse('Stripe/Mock/PurchaseSuccess.txt');//add success mock response from file
+		$response = $service->purchase();
+		$this->assertTrue($response->isSuccessful());
+		$this->assertFalse($response->isRedirect());
+		$this->assertSame("Captured", $payment->Status, "has the payment been captured");
 
-        //check messaging
-        $this->assertDOSContains(array(
-            array('ClassName' => 'PurchaseRequest'),
-            array('ClassName' => 'PurchasedResponse')
-        ), $payment->Messages());
-    }
+		//check messaging
+		$this->assertDOSContains(array(
+			array('ClassName' => 'PurchaseRequest'),
+			array('ClassName' => 'PurchasedResponse')
+		), $payment->Messages());
+	}
 
 
-    /**
-     * @return Payment
-     */
-    protected function getTestPaymentWithSavedCard() {
-        $payment = $this->payment->setGateway('Stripe');
-        $payment->setAmount(0);
-        $service = new SavedCardService($payment);
-        $this->setMockHttpResponse('Stripe/Mock/CreateCardSuccess.txt');
-        $response = $service->createCard(array(
-            'name' => 'My Test Card 1',
-            'number' => '4111111111111111',
-            'expiryMonth' => '5',
-            'expiryYear' => date("Y", strtotime("+1 year"))
-        ));
-        return $payment;
-    }
+	/**
+	 * @return Payment
+	 */
+	protected function getTestPaymentWithSavedCard() {
+		$payment = $this->payment->setGateway('Stripe');
+		$payment->setAmount(0);
+		$service = new SavedCardService($payment);
+		$this->setMockHttpResponse('Stripe/Mock/CreateCardSuccess.txt');
+		$response = $service->createCard(array(
+			'cardName' => 'My Test Card 1',
+			'number' => '4111111111111111',
+			'expiryMonth' => '5',
+			'expiryYear' => date("Y", strtotime("+1 year"))
+		));
+		return $payment;
+	}
 }

--- a/tests/SavedCardServiceTest.php
+++ b/tests/SavedCardServiceTest.php
@@ -17,7 +17,8 @@ class SavedCardServiceTest extends PaymentTest {
         $this->assertSame("Created", $payment->Status, 'does not process payment');
 
         /** @var SavedCreditCard $card */
-        $card = $payment->SavedCard();
+        $card = $payment->SavedCreditCard();
+	    Debug::dump($card);
         $this->assertNotNull($card);
         $this->assertInstanceOf('SavedCreditCard', $card);
         $this->assertEquals('My Test Card 1', $card->Name);
@@ -43,7 +44,7 @@ class SavedCardServiceTest extends PaymentTest {
         $this->assertTrue($response->isSuccessful());
 
         /** @var SavedCreditCard $card */
-        $card = $payment->SavedCard();
+        $card = $payment->SavedCreditCard();
         $this->assertEquals('************1111', $card->Name);
         $this->assertEquals('1111', $card->LastFourDigits);
     }
@@ -57,7 +58,7 @@ class SavedCardServiceTest extends PaymentTest {
     }
 
     public function testPayWithCard() {
-        $card = $this->getTestPaymentWithSavedCard()->SavedCard();
+        $card = $this->getTestPaymentWithSavedCard()->SavedCreditCard();
         $payment = $this->payment->setGateway('Stripe');
         $payment->setAmount(10.00);
         $payment->setCurrency('NZD');

--- a/tests/SavedCardServiceTest.php
+++ b/tests/SavedCardServiceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+class SavedCardServiceTest extends PaymentTest {
+
+    public function testCreateCard() {
+        $payment = $this->payment->setGateway('Stripe');
+        $service = new SavedCardService($payment);
+        $this->setMockHttpResponse('Stripe/Mock/CreateCardSuccess.txt');
+        $response = $service->createCard(array(
+            'name' => 'My Test Card 1',
+            'number' => '4111111111111111',
+            'expiryMonth' => '5',
+            'expiryYear' => date("Y", strtotime("+1 year"))
+        ));
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame("Created", $payment->Status, 'does not process payment');
+
+        /** @var SavedCard $card */
+        $card = $payment->SavedCard();
+        $this->assertNotNull($card);
+        $this->assertInstanceOf('SavedCard', $card);
+        $this->assertEquals('My Test Card 1', $card->Name);
+        $this->assertEquals('1111', $card->LastFourDigits);
+        $this->assertEquals('cus_1MZSEtqSghKx99', $card->CardReference);
+
+        //check messaging
+        $this->assertDOSContains(array(
+            array('ClassName' => 'CreateCardRequest'),
+            array('ClassName' => 'CreateCardResponse'),
+        ), $payment->Messages());
+    }
+
+    public function testCreateCardWithNoName() {
+        $payment = $this->payment->setGateway('Stripe');
+        $service = new SavedCardService($payment);
+        $this->setMockHttpResponse('Stripe/Mock/CreateCardSuccess.txt');
+        $response = $service->createCard(array(
+            'number' => '4111-1111-1111-1111',
+            'expiryMonth' => '5',
+            'expiryYear' => date("Y", strtotime("+1 year"))
+        ));
+        $this->assertTrue($response->isSuccessful());
+
+        /** @var SavedCard $card */
+        $card = $payment->SavedCard();
+        $this->assertEquals('************1111', $card->Name);
+        $this->assertEquals('1111', $card->LastFourDigits);
+    }
+
+    public function testUpdateCard() {
+        $this->markTestIncomplete('Need to test/implement updateCard');
+    }
+
+    public function testDeleteCard() {
+        $this->markTestIncomplete('Need to test/implement deleteCard');
+    }
+
+    public function testPayWithCard() {
+        $card = $this->getTestPaymentWithSavedCard()->SavedCard();
+        $payment = $this->payment->setGateway('Stripe');
+        $payment->setAmount(10.00);
+        $payment->setCurrency('NZD');
+        $payment->SavedCardID = $card->ID;
+        $payment->write();
+        $service = new PurchaseService($payment);
+        $this->setMockHttpResponse('Stripe/Mock/PurchaseSuccess.txt');//add success mock response from file
+        $response = $service->purchase();
+        $this->assertTrue($response->isSuccessful());
+        $this->assertFalse($response->isRedirect());
+        $this->assertSame("Captured", $payment->Status, "has the payment been captured");
+
+        //check messaging
+        $this->assertDOSContains(array(
+            array('ClassName' => 'PurchaseRequest'),
+            array('ClassName' => 'PurchasedResponse')
+        ), $payment->Messages());
+    }
+
+
+    /**
+     * @return Payment
+     */
+    protected function getTestPaymentWithSavedCard() {
+        $payment = $this->payment->setGateway('Stripe');
+        $payment->setAmount(0);
+        $service = new SavedCardService($payment);
+        $this->setMockHttpResponse('Stripe/Mock/CreateCardSuccess.txt');
+        $response = $service->createCard(array(
+            'name' => 'My Test Card 1',
+            'number' => '4111111111111111',
+            'expiryMonth' => '5',
+            'expiryYear' => date("Y", strtotime("+1 year"))
+        ));
+        return $payment;
+    }
+}


### PR DESCRIPTION
I’m working on an addition to the silverstripe-omnipay (and eventually shop) module that allows one to utilise omnipay’s credit card tokenising features if present (https://github.com/omnipay/omnipay#token-billing). This is just a temporary PR to discuss. There will be a corresponding PR to ss-shop to utilize this functionality. I'm currently using this on a beta site and it's working well using PayPal's vault API (https://github.com/omnipay/paypal/pull/21).

Jeremy mentioned that @halkyon and @chillu might have some thoughts or input on the architecture.
