### PR TITLE
bug fix: redirect after finished checkout

### DIFF
--- a/code/services/PaymentService.php
+++ b/code/services/PaymentService.php
@@ -117,7 +117,7 @@ abstract class PaymentService extends Object{
 			$this->setReturnUrl($data['returnUrl']);
 		}
 		if(isset($data['cancelUrl'])){
-			$this->setReturnUrl($data['cancelUrl']);
+			$this->setCancelUrl($data['cancelUrl']);
 		}
 	}
 


### PR DESCRIPTION
Hello,

after a successful payment (with manual or dummy as option) I always been redirected to the checkout page, where no items are in the cart anymore (makes sense). While trying to change the redirect URL to the details of the order (/checkout/order/XX or /account/order/XX) I found the "update" function in the PaymentService class being my problem here. The cancel URL gets set to the return URL after the returnURL has been set correctly. It looks like a mistake to me and I fixed this here. Can some one have a look at this?

spek
