### PR TITLE
ENHANCEMENT enable support for multiple manual gateways

### DIFF
--- a/code/model/GatewayInfo.php
+++ b/code/model/GatewayInfo.php
@@ -76,7 +76,14 @@ class GatewayInfo{
 	 * @return boolean
 	 */
 	public static function is_manual($gateway) {
-		return $gateway === 'Manual';
+		$manualGateways = Config::inst()->forClass('Payment')->manual_gateways;
+
+		// if not defined in config, set default manual gateway to 'Manual'
+		if (!$manualGateways)
+		{
+			$manualGateways = array('Manual');
+		}
+		return in_array($gateway,$manualGateways);
 	}
 
 	/**


### PR DESCRIPTION
I updated the method is_manual which checks if payment config declares an array of manual gateway names. If no configuration is found, it uses the default manual gateway Manual. This way, you have the ability to create multiple manual gateways, i.e. CreditAccount and BankTransfer and manage the configuration via the config.yml file.