### PR TITLE
WIP: Allow PaymentController to handle submitting custom omnipay data

### DIFF
--- a/code/controllers/PaymentController.php
+++ b/code/controllers/PaymentController.php
@@ -257,10 +257,8 @@ class PaymentController extends Page_Controller{
 	 */
 	public function pay($data, $form) {
 		$payment = $this->getCurrentPayment();
-		//data from form is safe
-		$data = $form->getData();
-		//TODO: pass in custom data
-		return $this->processPayment($payment, $data);
+		
+		return $this->processPayment($payment, $form->getData());
 	}
 
 	/**
@@ -270,6 +268,14 @@ class PaymentController extends Page_Controller{
 	 * @param  array $data
 	 */
 	protected function processPayment(Payment $payment, $data) {
+		if($this->payable->hasMethod("getOmnipayMappedData")){
+			$odata = $this->payable->getOmnipayMappedData();
+			if(!is_array($odata)){
+				throw new UnexpectedValueException("getOmnipayMappedData must return an array");
+			}
+			$data = array_merge($odata, $data);
+		}
+
 		$response = PurchaseService::create($payment)
 					->setReturnUrl($this->successurl)
 					->setCancelUrl($this->cancelurl)

--- a/tests/PaymentControllerTest.php
+++ b/tests/PaymentControllerTest.php
@@ -20,6 +20,7 @@ class PaymentControllerTest extends PaymentTest{
 		$parent = new Page_Controller(new Page(array(
 			'URLSegment' => 'test'
 		)));
+
 		return new PaymentController($parent, "payment", $payable, $payable->Cost);
 	}
 
@@ -68,21 +69,45 @@ class PaymentControllerTest extends PaymentTest{
 		$this->markTestIncomplete();
 	}
 
+	/**
+	 * Test payment via omnipay
+	 */
 	public function testPayment() {
-		//$controller->pay()
-		$this->markTestIncomplete();
+
+		$controller = $this->getController();
+		$payable = $controller->getPayable();
+		//set current payment
+
+		$data = array(
+			'action_pay' => 'Make Payment'
+		);
+		$form = $controller->GatewayDataForm();
+		$form->loadDataFrom($data);
+		$controller->pay($data, $form);
+		
+		$this->assertEquals(100, $payable->TotalPaid());
 	}
 	
 }
 
 class PaymentControllerTest_Payable extends DataObject implements TestOnly{
 
+	protected $customdata = array();
+
 	private static $extensions = array(
 		"Payable"
 	);
 
-	function getCost(){
+	public function setCustomData($customdata) {
+		$this->customdata = $customdata;
+	}
+
+	public function getCost(){
 		return 100;
+	}
+
+	public function getOmnipayMappedData() {
+		return $this->customdata;
 	}
 
 }


### PR DESCRIPTION
When completed, this work will allow adding a function to your payable model which automatically gathers, and maps the appropriate data to omnipay.

For example, given a `Registration` object:
```php
class Registration extends DataObject{

   private static $extensions = array("Payable");

   public function getOmnipayMappedData() {
       return array(
               'firstName' => $this->FirstName,
               'email' => $this->Email,
               'phone' => $this->Phone,
               'city' => $this->Address()->City
       );
   }

}
```
