### PR TITLE
Improve integration with async gateways

### DIFF
--- a/code/PaymentGatewayController.php
+++ b/code/PaymentGatewayController.php
@@ -59,13 +59,18 @@ class PaymentGatewayController extends \Controller
 
         $intent = null;
         switch ($payment->Status){
+            // We have to check for both states here, since the notification might come in before the gateway returns
+            // if that's the case, the status of the payment will already be set to 'Authorized'
             case 'PendingAuthorization':
+            case 'Authorized':
                 $intent = ServiceFactory::INTENT_AUTHORIZE;
                 break;
             case 'PendingCapture':
                 $intent = ServiceFactory::INTENT_CAPTURE;
                 break;
+            // Both states have to be checked (see explanation with 'Authorized')
             case 'PendingPurchase':
+            case 'Captured':
                 $intent = ServiceFactory::INTENT_PURCHASE;
                 break;
             case 'PendingRefund':

--- a/code/extensions/Payable.php
+++ b/code/extensions/Payable.php
@@ -70,4 +70,21 @@ class Payable extends DataExtension {
         return $paid;
     }
 
+    /**
+     * Whether or not the model has payments that are in a pending state.
+     * Can be used to show a waiting screen to the user or similar.
+     * @return bool
+     */
+    public function HasPendingPayments()
+    {
+        return $this->owner->Payments()
+            ->filter('Status', array(
+                'PendingAuthorization',
+                'PendingPurchase',
+                'PendingCapture',
+                'PendingRefund',
+                'PendingVoid'
+            ))->count() > 0;
+    }
+
 }


### PR DESCRIPTION
Fix issue where an offsite-payment form would return but payment was already marked complete due to async notification.

Added unit-test to check for above issue.
Added helper method to detect pending payments on `Payable`