### PR TITLE
No longer use PaymentMessages to store/retrieve Transaction-Reference…

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,12 +284,15 @@ Using function chaining, we can create and configure a new payment object, and s
 The response object has a `redirectOrRespond` function built in that will either redirect the user to the external gateway site, or to the given return url.
 
 ```php
-// create the payment object
-$payment = Payment::create()->init("PxPayGateway", 100, "NZD")->write();
+// Create the payment object. We pass the desired success and failure URLs as parameter to the payment
+$payment = Payment::create()
+    ->init("PxPayGateway", 100, "NZD")
+    ->setSuccessUrl($this->Link('complete')."/".$donation->ID)
+    ->setFailureUrl($this->Link()."?message=payment cancelled")
+    ->write();
 
-$response = ServiceFactory::create()->getService($payment, ServiceFactory::INTENT_PAYMENT)
-    ->setReturnUrl($this->Link('complete')."/".$donation->ID)
-    ->setCancelUrl($this->Link()."?message=payment cancelled")
+$response = ServiceFactory::create()
+    ->getService($payment, ServiceFactory::INTENT_PAYMENT)
     ->initiate($form->getData());
 
 return $response->redirectOrRespond();
@@ -297,7 +300,7 @@ return $response->redirectOrRespond();
 
 Of course you don't need to chain all of these functions, as you may want to redirect somewhere else, or do some further setup.
 
-After payment has been made, the user will be redirected to the given return url (or cancel url, if they cancelled).
+After payment has been made, the user will be redirected to the given success url (or failure url, if they cancelled).
 
 ### Passing correct data to the purchase function
 
@@ -325,7 +328,8 @@ shippingCountry
 shippingPhone
 ```
 
-**Note:** `transactionId` can be a reference that identifies the thing you are paying for, such as an order reference id. It usually shows up on bank statements for reconciliation purposes, but ultimately depends how the gateway uses it.
+**Note:** `transactionId` can be a reference that identifies the thing you are paying for, such as an order reference id.
+It usually shows up on bank statements for reconciliation purposes, but ultimately depends how the gateway uses it.
 
 ### Extension hooks
 

--- a/code/GatewayInfo.php
+++ b/code/GatewayInfo.php
@@ -81,7 +81,7 @@ class GatewayInfo
 
         if ($legacyTranslation = _t('Payment.' . $name)) {
             \Deprecation::notice(
-                '2.0',
+                '3.0',
                 'Gateway name translations should be in Gateway group, eg. Gateway.' . $name,
                 \Deprecation::SCOPE_GLOBAL
             );

--- a/code/Service/CaptureService.php
+++ b/code/Service/CaptureService.php
@@ -48,13 +48,10 @@ class CaptureService extends NotificationCompleteService
         if (!GatewayInfo::isManual($this->payment->Gateway)) {
             if (!empty($data['transactionReference'])) {
                 $reference = $data['transactionReference'];
+            } elseif (!empty($data['receipt'])) { // legacy code?
+                $reference = $data['receipt'];
             } else {
-                if (!empty($data['receipt'])) { // legacy code?
-                    $reference = $data['receipt'];
-                } else {
-                    $msg = $this->payment->getLatestMessageOfType('AuthorizedResponse');
-                    $reference = $msg ? $msg->Reference : null;
-                }
+                $reference = $this->payment->TransactionReference;
             }
 
             if (empty($reference)) {
@@ -104,18 +101,17 @@ class CaptureService extends NotificationCompleteService
             if ($serviceResponse->isError()) {
                 $this->createMessage($this->errorMessageType, $response);
             } else {
-                $this->markCompleted($serviceResponse, $response);
+                $this->markCompleted($this->endState, $serviceResponse, $response);
             }
         }
 
         return $serviceResponse;
     }
 
-    protected function markCompleted(ServiceResponse $serviceResponse, $gatewayMessage)
+    protected function markCompleted($endStatus, ServiceResponse $serviceResponse, $gatewayMessage)
     {
+        parent::markCompleted($endStatus, $serviceResponse, $gatewayMessage);
         $this->createMessage('CapturedResponse', $gatewayMessage);
-        $this->payment->Status = $this->endState;
-        $this->payment->write();
         $this->payment->extend('onCaptured', $serviceResponse);
     }
 }

--- a/code/Service/NotificationCompleteService.php
+++ b/code/Service/NotificationCompleteService.php
@@ -60,41 +60,21 @@ abstract class NotificationCompleteService extends PaymentService
             return $serviceResponse;
         }
 
-        // Find the matching request message
-        $msg = $this->payment->getLatestMessageOfType($this->requestMessageType);
-
-        // safety check the payment number against the transaction reference we get from the notification
+        // safety check the payment transaction-number against the transaction reference we get from the notification
         if (!(
-            $msg &&
             $serviceResponse->getOmnipayResponse() &&
-            $serviceResponse->getOmnipayResponse()->getTransactionReference() == $msg->Reference
+            $serviceResponse->getOmnipayResponse()->getTransactionReference() == $this->payment->TransactionReference
         )) {
-            // flag as an error if transaction references don't match or aren't available
+            // flag as an error if transaction references don't match
             $serviceResponse->addFlag(ServiceResponse::SERVICE_ERROR);
-            $this->createMessage(
-                $this->errorMessageType,
-                $msg  ? 'No transaction reference found for this Payment!' : 'Transaction references do not match!'
-            );
+            $this->createMessage($this->errorMessageType, 'Transaction references do not match!');
         }
 
         // check if we're done
         if (!$serviceResponse->isError() && !$serviceResponse->isAwaitingNotification()) {
-            $this->markCompleted($serviceResponse, $serviceResponse->getOmnipayResponse());
+            $this->markCompleted($this->endState, $serviceResponse, $serviceResponse->getOmnipayResponse());
         }
 
         return $serviceResponse;
     }
-
-    /**
-     * Mark this payment process as completed.
-     * Here you'll usually do the following:
-     * * Set the proper status on Payment and write the payment.
-     * * Log/Write the GatewayMessage
-     * * Call a "complete" hook
-     *
-     * @param ServiceResponse $serviceResponse the service response
-     * @param mixed $gatewayMessage the message from Omnipay
-     * @return void
-     */
-    abstract protected function markCompleted(ServiceResponse $serviceResponse, $gatewayMessage);
 }

--- a/code/Service/VoidService.php
+++ b/code/Service/VoidService.php
@@ -42,13 +42,10 @@ class VoidService extends NotificationCompleteService
         if (!GatewayInfo::isManual($this->payment->Gateway)) {
             if (!empty($data['transactionReference'])) {
                 $reference = $data['transactionReference'];
+            } elseif (!empty($data['receipt'])) { // legacy code?
+                $reference = $data['receipt'];
             } else {
-                if (!empty($data['receipt'])) { // legacy code?
-                    $reference = $data['receipt'];
-                } else {
-                    $msg = $this->payment->getLatestMessageOfType(array('AuthorizedResponse', 'PurchasedResponse'));
-                    $reference = $msg ? $msg->Reference : null;
-                }
+                $reference = $this->payment->TransactionReference;
             }
 
             if (empty($reference)) {
@@ -96,18 +93,17 @@ class VoidService extends NotificationCompleteService
             if ($serviceResponse->isError()) {
                 $this->createMessage($this->errorMessageType, $response);
             } else {
-                $this->markCompleted($serviceResponse, $response);
+                $this->markCompleted($this->endState, $serviceResponse, $response);
             }
         }
 
         return $serviceResponse;
     }
 
-    protected function markCompleted(ServiceResponse $serviceResponse, $gatewayMessage)
+    protected function markCompleted($endStatus, ServiceResponse $serviceResponse, $gatewayMessage)
     {
+        parent::markCompleted($endStatus, $serviceResponse, $gatewayMessage);
         $this->createMessage('VoidedResponse', $gatewayMessage);
-        $this->payment->Status = $this->endState;
-        $this->payment->write();
         $this->payment->extend('onVoid', $serviceResponse);
     }
 }

--- a/code/model/Payment.php
+++ b/code/model/Payment.php
@@ -12,12 +12,21 @@ use SilverStripe\Omnipay\GatewayInfo;
  */
 final class Payment extends DataObject
 {
-
     private static $db = array(
-        'Gateway' => 'Varchar(128)', //this is the omnipay 'short name'
-        'Money' => 'Money', //contains Amount and Currency
+        // this is the omnipay 'short name'
+        'Gateway' => 'Varchar(128)',
+        //contains Amount and Currency
+        'Money' => 'Money',
+        // status
         'Status' => "Enum('Created,PendingAuthorization,Authorized,PendingPurchase,PendingCapture,Captured,PendingRefund,Refunded,PendingVoid,Void','Created')",
-        'Identifier' => 'Varchar(64)'
+        // unique identifier for this payment
+        'Identifier' => 'Varchar(64)',
+        // How this payment is being referenced by the payment provider
+        'TransactionReference' => 'Varchar(255)',
+        // Success URL
+        'SuccessUrl' => 'Text',
+        // Failure URL
+        'FailureUrl' => 'Text'
     );
 
     private static $has_many = array(
@@ -105,6 +114,32 @@ final class Payment extends DataObject
         $this->setGateway($gateway);
         $this->setAmount($amount);
         $this->setCurrency($currency);
+        return $this;
+    }
+
+    /**
+     * Set the url to redirect to after payment is made/attempted.
+     * This function also populates the FailureUrl, if it is empty.
+     * @param string $url
+     * @return $this object for chaining
+     */
+    public function setSuccessUrl($url)
+    {
+        $this->setField('SuccessUrl', $url);
+        if (!$this->FailureUrl) {
+            $this->setField('FailureUrl', $url);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the url to redirect to after payment is cancelled
+     * @return $this this object for chaining
+     */
+    public function setFailureUrl($url)
+    {
+        $this->setField('FailureUrl', $url);
         return $this;
     }
 

--- a/tests/BasePurchaseServiceTest.php
+++ b/tests/BasePurchaseServiceTest.php
@@ -181,6 +181,10 @@ abstract class BasePurchaseServiceTest extends PaymentTest
         $this->assertTrue($response->getOmnipayResponse()->isSuccessful());
         $this->assertSame($this->completeStatus, $payment->Status);
         $this->assertFalse($response->isError());
+        // payment should get the transaction reference from Omnipay assigned
+        $reference = $response->getOmnipayResponse()->getTransactionReference();
+        $this->assertNotNull($reference);
+        $this->assertEquals($payment->TransactionReference, $reference);
 
         //check messaging
         $this->assertDOSContains($this->offsiteSuccessMessages, $payment->Messages());
@@ -233,8 +237,8 @@ abstract class BasePurchaseServiceTest extends PaymentTest
         //exception when trying to run functions that require a gateway
         $payment = $this->payment;
         $service = $this->getService(
-            $payment->init("FantasyGateway", 100, "NZD")
-        )->setReturnUrl("complete");
+            $payment->init("FantasyGateway", 100, "NZD")->setSuccessUrl("complete")
+        );
 
         // Will throw an exception since the gateway doesn't exist
         $service->initiate();
@@ -401,14 +405,12 @@ abstract class BasePurchaseServiceTest extends PaymentTest
             return $isNotification;
         });
         $payment = $this->payment->setGateway('PaymentExpress_PxPay');
+        $payment->setFailureUrl('my/cancel/url')->setSuccessUrl('my/return/url');
 
         $service = $this->getService($payment);
         $service->setGatewayFactory($this->stubGatewayFactory($stubGateway));
 
-        $serviceResponse = $service
-            ->setCancelUrl('my/cancel/url')
-            ->setReturnUrl('my/return/url')
-            ->initiate();
+        $serviceResponse = $service->initiate();
 
         // we should get a redirect
         $this->assertTrue($serviceResponse->isRedirect());
@@ -459,14 +461,12 @@ abstract class BasePurchaseServiceTest extends PaymentTest
             return $isNotification;
         });
         $payment = $this->payment->setGateway('PaymentExpress_PxPay');
+        $payment->setFailureUrl('my/cancel/url')->setSuccessUrl('my/return/url');
 
         $service = $this->getService($payment);
         $service->setGatewayFactory($this->stubGatewayFactory($stubGateway));
 
-        $serviceResponse = $service
-            ->setCancelUrl('my/cancel/url')
-            ->setReturnUrl('my/return/url')
-            ->initiate();
+        $serviceResponse = $service->initiate();
 
         // we should get a redirect
         $this->assertTrue($serviceResponse->isRedirect());
@@ -516,16 +516,13 @@ abstract class BasePurchaseServiceTest extends PaymentTest
             return $isNotification;
         });
         $payment = $this->payment->setGateway('PaymentExpress_PxPay');
-
+        $payment->setFailureUrl('my/cancel/url')->setSuccessUrl('my/return/url');
         $service = $this->getService($payment);
 
         // register our mock gateway factory as injection
         Injector::inst()->registerService($this->stubGatewayFactory($stubGateway), 'Omnipay\Common\GatewayFactory');
 
-        $serviceResponse = $service
-            ->setCancelUrl('my/cancel/url')
-            ->setReturnUrl('my/return/url')
-            ->initiate();
+        $serviceResponse = $service->initiate();
 
         // we should get a redirect
         $this->assertTrue($serviceResponse->isRedirect());

--- a/tests/PaymentModelTest.php
+++ b/tests/PaymentModelTest.php
@@ -92,4 +92,40 @@ class PaymentModelTest extends PaymentTest
         $payment->Identifier = "somethingelse";
         $this->assertEquals("UNIQUEHASH23q5123tqasdf", $payment->Identifier);
     }
+
+    public function testTargetUrls()
+    {
+        $payment = new Payment();
+        $payment->setSuccessUrl("abc/123");
+
+        // setting the success Url should also set the failure url (if not set)
+        $this->assertEquals("abc/123", $payment->SuccessUrl);
+        $this->assertEquals("abc/123", $payment->FailureUrl);
+
+
+        $payment->setFailureUrl("xyz/blah/2345235?andstuff=124124#hash");
+        $this->assertEquals("xyz/blah/2345235?andstuff=124124#hash", $payment->FailureUrl);
+
+        $payment->setSuccessUrl("abc/updated");
+        $this->assertEquals("abc/updated", $payment->SuccessUrl);
+        $this->assertEquals("xyz/blah/2345235?andstuff=124124#hash", $payment->FailureUrl);
+    }
+
+    public function testGatewayMutability()
+    {
+        $payment = Payment::create()->init('Manual', 120, 'EUR');
+
+        $this->assertEquals($payment->Gateway, 'Manual');
+
+        $payment->Gateway = 'Dummy';
+        $this->assertEquals($payment->Gateway, 'Dummy');
+        
+        $payment->Status = 'Authorized';
+        $payment->Gateway = 'Manual';
+        $this->assertEquals(
+            $payment->Gateway,
+            'Dummy',
+            'Payment status should be immutable once it\'s no longer Created'
+        );
+    }
 }

--- a/tests/PaymentServiceTest.php
+++ b/tests/PaymentServiceTest.php
@@ -17,16 +17,6 @@ class PaymentServiceTest extends PaymentTest
         $this->service = $this->factory->getService($this->payment, ServiceFactory::INTENT_PURCHASE);
     }
 
-    public function testRedirectUrl()
-    {
-        $this->service
-            ->setReturnUrl("abc/123")
-            ->setCancelUrl("xyz/blah/2345235?andstuff=124124#hash");
-
-        $this->assertEquals("abc/123", $this->service->getReturnUrl());
-        $this->assertEquals("xyz/blah/2345235?andstuff=124124#hash", $this->service->getCancelUrl());
-    }
-
     public function testCancel()
     {
         $response = $this->service->cancel();

--- a/tests/payment.yml
+++ b/tests/payment.yml
@@ -12,12 +12,15 @@ Payment:
     MoneyCurrency: USD
     Status: PendingPurchase
     Identifier: UNIQUEHASH23q5123tqasdf
+    SuccessUrl: 'shop/complete'
+    FailureUrl: 'shop/incomplete'
   payment3:
     Gateway: PaymentExpress_PxPay
     MoneyAmount: 769.50
     MoneyCurrency: AUD
     Status: Captured
     Identifier: c3b502a48a4740c063e1732de4cc8077
+    TransactionReference: paymentReceipt
   payment4:
     Gateway: UknownGateway
     MoneyAmount: 2.50
@@ -29,12 +32,15 @@ Payment:
     MoneyCurrency: USD
     Status: PendingAuthorization
     Identifier: 62b26e0a8a77f60cce3e9a7994087b0e
+    SuccessUrl: 'shop/complete'
+    FailureUrl: 'shop/incomplete'
   payment6:
     Gateway: PaymentExpress_PxPay
     MoneyAmount: 123.45
     MoneyCurrency: USD
     Status: Authorized
     Identifier: 51efcc0e94718dd80d97b1281762a9bc
+    TransactionReference: authorizedPaymentReceipt
 
 GatewayMessage:
   message1:
@@ -43,8 +49,6 @@ GatewayMessage:
     Message:
     Code:
     PaymentID: =>Payment.payment2
-    SuccessURL: 'shop/complete'
-    FailureURL: 'shop/incomplete'
   message2:
     ClassName: PurchaseRedirectResponse
     PaymentID: =>Payment.payment2
@@ -54,8 +58,6 @@ GatewayMessage:
     Message:
     Code:
     PaymentID: =>Payment.payment5
-    SuccessURL: 'shop/complete'
-    FailureURL: 'shop/incomplete'
   message4:
     ClassName: AuthorizeRedirectResponse
     PaymentID: =>Payment.payment5


### PR DESCRIPTION
… and success- and failure URLs.

These parameters are now stored on the Payment itself.
Setting return- and cancel-Url on services is now deprecated.
Refactored payment-services a bit.
Updated services and unit-tests.

Fixes #49 