### PR TITLE
Multiple and single partial payments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Each Gateway can have the following settings:
 | `required_fields`        | *array*          | An array of required form-fields
 | `parameters`             | *map*            | All gateway parameters that will be passed along to the Omnipay Gateway instance
 | `is_offsite`             | *boolean*        | You can explicitly mark this gateway as being offsite. Use with caution and only if the system fails to automatically determine this
-| `can_capture`            | *boolean/string* | Set how/if authorized payments can be captured. Defaults to "partial". Valid values are "off" or `false` (capturing disabled), "full" (can only capture full amounts), "partial" or `true` (can capture partially)
-| `can_refund`             | *boolean/string* | Set how/if captured payments can be refunded. Defaults to "partial". Valid values are "off" or `false` (refunding disabled), "full" (can only refund full amounts), "partial" or `true` (can refund partially)
+| `can_capture`            | *boolean/string* | Set how/if authorized payments can be captured. Defaults to "partial". Valid values are "off" or `false` (capturing disabled), "full" (can only capture full amounts), "partial" or `true` (can capture partially) and "multiple" which allows multiple partial captures.
+| `can_refund`             | *boolean/string* | Set how/if captured payments can be refunded. Defaults to "partial". Valid values are "off" or `false` (refunding disabled), "full" (can only refund full amounts), "partial" or `true` (can refund partially) and "multiple" which allows multiple partial refunds.
 | `can_void`               | *boolean*        | Whether or not voiding of authorized payments should be allowed. Defaults to *true*
 | `max_capture`            | *mixed*          | Configuration for excess capturing of authorized amounts. See the **max_capture** section further below.
 
@@ -162,7 +162,7 @@ GatewayInfo:
 GatewayInfo:
   PayPal_Express:
     # configure both percentage and a fixed max. amount
-    max_capture: 
+    max_capture:
       percent: 15
       amount: 75
 ```
@@ -173,7 +173,7 @@ The example above models the PayPal example with 115%, capped at USD $75. The am
 GatewayInfo:
   PayPal_Express:
     # configure both percentage and a fixed max. amount per currency
-    max_capture: 
+    max_capture:
       percent: 15
       amount:
         USD: 75

--- a/tests/GatewayInfoTest.php
+++ b/tests/GatewayInfoTest.php
@@ -387,16 +387,20 @@ class GatewayInfoTest extends SapphireTest
         // a gateway without explicitly disabling void, capture and refund should allow per default
         $this->assertTrue(GatewayInfo::allowCapture('Dummy'));
         $this->assertTrue(GatewayInfo::allowPartialCapture('Dummy'));
+        $this->assertEquals(GatewayInfo::PARTIAL, GatewayInfo::captureMode('Dummy'));
         $this->assertTrue(GatewayInfo::allowRefund('Dummy'));
         $this->assertTrue(GatewayInfo::allowPartialRefund('Dummy'));
+        $this->assertEquals(GatewayInfo::PARTIAL, GatewayInfo::refundMode('Dummy'));
         $this->assertTrue(GatewayInfo::allowVoid('Dummy'));
 
         // check if the config is respected
         $this->assertTrue(GatewayInfo::allowCapture('PaymentExpress_PxPay'));
         $this->assertTrue(GatewayInfo::allowPartialCapture('PaymentExpress_PxPay'));
+        $this->assertEquals(GatewayInfo::PARTIAL, GatewayInfo::captureMode('PaymentExpress_PxPay'));
         $this->assertTrue(GatewayInfo::allowRefund('PaymentExpress_PxPay'));
         $this->assertFalse(GatewayInfo::allowPartialRefund('PaymentExpress_PxPay'));
         $this->assertFalse(GatewayInfo::allowVoid('PaymentExpress_PxPay'));
+        $this->assertEquals(GatewayInfo::FULL, GatewayInfo::refundMode('PaymentExpress_PxPay'));
 
         // check with explicit values
         Config::inst()->update('GatewayInfo', 'PaymentExpress_PxPay', array(
@@ -407,20 +411,24 @@ class GatewayInfoTest extends SapphireTest
 
         $this->assertTrue(GatewayInfo::allowCapture('PaymentExpress_PxPay'));
         $this->assertFalse(GatewayInfo::allowPartialCapture('PaymentExpress_PxPay'));
+        $this->assertEquals(GatewayInfo::FULL, GatewayInfo::captureMode('PaymentExpress_PxPay'));
         $this->assertFalse(GatewayInfo::allowRefund('PaymentExpress_PxPay'));
         $this->assertFalse(GatewayInfo::allowPartialRefund('PaymentExpress_PxPay'));
+        $this->assertEquals(GatewayInfo::OFF, GatewayInfo::refundMode('PaymentExpress_PxPay'));
         $this->assertFalse(GatewayInfo::allowVoid('PaymentExpress_PxPay'));
 
         Config::inst()->update('GatewayInfo', 'PaymentExpress_PxPay', array(
-            'can_capture' => 'partial',
+            'can_capture' => 'multiple',
             'can_refund' => 'full',
             'can_void' => 'false'
         ));
 
         $this->assertTrue(GatewayInfo::allowCapture('PaymentExpress_PxPay'));
         $this->assertTrue(GatewayInfo::allowPartialCapture('PaymentExpress_PxPay'));
+        $this->assertEquals(GatewayInfo::MULTIPLE, GatewayInfo::captureMode('PaymentExpress_PxPay'));
         $this->assertTrue(GatewayInfo::allowRefund('PaymentExpress_PxPay'));
         $this->assertFalse(GatewayInfo::allowPartialRefund('PaymentExpress_PxPay'));
+        $this->assertEquals(GatewayInfo::FULL, GatewayInfo::refundMode('PaymentExpress_PxPay'));
         $this->assertFalse(GatewayInfo::allowVoid('PaymentExpress_PxPay'));
 
         // check with true/false
@@ -432,8 +440,10 @@ class GatewayInfoTest extends SapphireTest
 
         $this->assertFalse(GatewayInfo::allowCapture('PaymentExpress_PxPay'));
         $this->assertFalse(GatewayInfo::allowPartialCapture('PaymentExpress_PxPay'));
+        $this->assertEquals(GatewayInfo::OFF, GatewayInfo::captureMode('PaymentExpress_PxPay'));
         $this->assertTrue(GatewayInfo::allowRefund('PaymentExpress_PxPay'));
         $this->assertTrue(GatewayInfo::allowPartialRefund('PaymentExpress_PxPay'));
+        $this->assertEquals(GatewayInfo::PARTIAL, GatewayInfo::refundMode('PaymentExpress_PxPay'));
         $this->assertTrue(GatewayInfo::allowVoid('PaymentExpress_PxPay'));
 
         // check with "truthy" and "falsy" values
@@ -445,8 +455,10 @@ class GatewayInfoTest extends SapphireTest
 
         $this->assertFalse(GatewayInfo::allowCapture('PaymentExpress_PxPay'));
         $this->assertFalse(GatewayInfo::allowPartialCapture('PaymentExpress_PxPay'));
+        $this->assertEquals(GatewayInfo::OFF, GatewayInfo::captureMode('PaymentExpress_PxPay'));
         $this->assertTrue(GatewayInfo::allowRefund('PaymentExpress_PxPay'));
         $this->assertTrue(GatewayInfo::allowPartialRefund('PaymentExpress_PxPay'));
+        $this->assertEquals(GatewayInfo::PARTIAL, GatewayInfo::refundMode('PaymentExpress_PxPay'));
         $this->assertTrue(GatewayInfo::allowVoid('PaymentExpress_PxPay'));
     }
 }


### PR DESCRIPTION
Implemented distinction between "partial" and "multiple" partial payments (for capture and refunds).

Changed how excess payments are stored.
Updated documentation and unit-tests.