### PR TITLE
Fix issue when trying to look up a field that doesn’t occur in the rename-map

### DIFF
--- a/code/GatewayFieldsFactory.php
+++ b/code/GatewayFieldsFactory.php
@@ -354,7 +354,11 @@ class GatewayFieldsFactory
             return $this->getFieldNames($defaultName);
         }
 
-        return $this->renamemap[$defaultName];
+        if (isset($this->renamemap[$defaultName])) {
+            return $this->renamemap[$defaultName];
+        }
+
+        return $defaultName;
     }
 
     /**


### PR DESCRIPTION
Improved unit-tests for field-renaming.