### PR TITLE
Made service extension hooks supply ArrayData instead of array

### DIFF
--- a/code/Service/AuthorizeService.php
+++ b/code/Service/AuthorizeService.php
@@ -33,7 +33,7 @@ class AuthorizeService extends PaymentService
         $gatewayData = $this->gatherGatewayData($data);
 
         $this->extend('onBeforeAuthorize', $gatewayData);
-        $request = $this->oGateway()->authorize($gatewayData);
+        $request = $this->oGateway()->authorize($gatewayData->toMap());
         $this->extend('onAfterAuthorize', $request);
 
         $this->createMessage('AuthorizeRequest', $request);
@@ -96,7 +96,7 @@ class AuthorizeService extends PaymentService
         $gatewayData = $this->gatherGatewayData($data);
 
         $this->extend('onBeforeCompleteAuthorize', $gatewayData);
-        $request = $gateway->completeAuthorize($gatewayData);
+        $request = $gateway->completeAuthorize($gatewayData->toMap());
         $this->extend('onAfterCompleteAuthorize', $request);
 
         $this->createMessage('CompleteAuthorizeRequest', $request);

--- a/code/Service/CaptureService.php
+++ b/code/Service/CaptureService.php
@@ -100,7 +100,7 @@ class CaptureService extends NotificationCompleteService
             throw new InvalidParameterException('This payment cannot be partially captured (unsupported by gateway).');
         }
 
-        $gatewayData = array_merge(
+        $gatewayData = new \ArrayData(array_merge(
             $data,
             array(
                 'amount' => (float)$amount,
@@ -108,10 +108,10 @@ class CaptureService extends NotificationCompleteService
                 'transactionReference' => $reference,
                 'notifyUrl' => $this->getEndpointUrl('notify')
             )
-        );
+        ));
 
         $this->extend('onBeforeCapture', $gatewayData);
-        $request = $this->oGateway()->capture($gatewayData);
+        $request = $this->oGateway()->capture($gatewayData->toMap());
         $this->extend('onAfterCapture', $request);
 
         $message = $this->createMessage($this->requestMessageType, $request);

--- a/code/Service/PaymentService.php
+++ b/code/Service/PaymentService.php
@@ -202,7 +202,7 @@ abstract class PaymentService extends \Object
      *
      * @param array $data incoming data for the gateway
      * @param boolean $includeCardOrToken whether or not to include card or token data
-     * @return array
+     * @return \ArrayData
      */
     protected function gatherGatewayData($data = array(), $includeCardOrToken = true)
     {
@@ -240,7 +240,7 @@ abstract class PaymentService extends \Object
             }
         }
 
-        return $gatewaydata;
+        return new \ArrayData($gatewaydata);
     }
 
     /**

--- a/code/Service/PurchaseService.php
+++ b/code/Service/PurchaseService.php
@@ -39,7 +39,7 @@ class PurchaseService extends PaymentService
         $gatewayData = $this->gatherGatewayData($data);
 
         $this->extend('onBeforePurchase', $gatewayData);
-        $request = $this->oGateway()->purchase($gatewayData);
+        $request = $this->oGateway()->purchase($gatewayData->toMap());
         $this->extend('onAfterPurchase', $request);
 
         $this->createMessage('PurchaseRequest', $request);
@@ -101,7 +101,7 @@ class PurchaseService extends PaymentService
         $gatewayData = $this->gatherGatewayData($data);
 
         $this->extend('onBeforeCompletePurchase', $gatewayData);
-        $request = $gateway->completePurchase($gatewayData);
+        $request = $gateway->completePurchase($gatewayData->toMap());
         $this->extend('onAfterCompletePurchase', $request);
 
         $this->createMessage('CompletePurchaseRequest', $request);

--- a/code/Service/RefundService.php
+++ b/code/Service/RefundService.php
@@ -93,7 +93,7 @@ class RefundService extends NotificationCompleteService
             throw new InvalidParameterException('This payment cannot be partially refunded (unsupported by gateway).');
         }
 
-        $gatewayData = array_merge(
+        $gatewayData = new \ArrayData(array_merge(
             $data,
             array(
                 'amount' => (float)$amount,
@@ -101,10 +101,10 @@ class RefundService extends NotificationCompleteService
                 'transactionReference' => $reference,
                 'notifyUrl' => $this->getEndpointUrl('notify')
             )
-        );
+        ));
 
         $this->extend('onBeforeRefund', $gatewayData);
-        $request = $this->oGateway()->refund($gatewayData);
+        $request = $this->oGateway()->refund($gatewayData->toMap());
         $this->extend('onAfterRefund', $request);
 
         $message = $this->createMessage($this->requestMessageType, $request);

--- a/code/Service/VoidService.php
+++ b/code/Service/VoidService.php
@@ -62,16 +62,16 @@ class VoidService extends NotificationCompleteService
             );
         }
 
-        $gatewayData = array_merge(
+        $gatewayData = new \ArrayData(array_merge(
             $data,
             array(
                 'transactionReference' => $reference,
                 'notifyUrl' => $this->getEndpointUrl('notify')
             )
-        );
+        ));
 
         $this->extend('onBeforeVoid', $gatewayData);
-        $request = $this->oGateway()->void($gatewayData);
+        $request = $this->oGateway()->void($gatewayData->toMap());
         $this->extend('onAfterVoid', $request);
 
         $message = $this->createMessage($this->requestMessageType, $request);


### PR DESCRIPTION
By sending an ArrayData Object trough the extension hook the data becomes mutable. 

I encountered an issue with certain data being set by the Silvershop module (transactionID) that was not accepted by the payment gateway i am using because special characters where set. By having mutable data in the hooks i'm able to alter the transactionID.