### PR TITLE
Fix type on PayPal_Express Example

### DIFF
--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -54,7 +54,7 @@ Payment:
     - 'Dummy'
 
 GatewayInfo:
-  Paypal_Express:
+  PayPal_Express:
     parameters:
       testMode: true
 ---
@@ -118,7 +118,9 @@ GatewayInfo:
         EUR: 70
 ```
 
-The `Payment` class comes with a helper method `getMaxCaptureAmount` that will calculate the max. amount of money you can capture. With the PayPal example above, we'll get the following:
+The `Payment` class comes with a helper method `getMaxCaptureAmount` that will calculate the max. amount of money you can capture. With the 
+
+example above, we'll get the following:
 
 ```php
 $payment = Payment::create()->init('PayPal_Express', 121, 'USD');


### PR DESCRIPTION
I keep copy/pasting this, getting a security error and forgetting there is a typo! Driving me nuts!