### PR TITLE
Make gatewayinfo respect `false` settings on `is_offsite`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   - export PATH=~/.composer/vendor/bin:$PATH
   - composer validate
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:^2.0 --no-update; fi
-  - composer update
+  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
   - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
 
 script:

--- a/src/GatewayInfo.php
+++ b/src/GatewayInfo.php
@@ -148,8 +148,10 @@ class GatewayInfo
      */
     public static function isOffsite($gateway)
     {
-        if (self::getConfigSetting($gateway, 'is_offsite')) {
-            return true;
+        $configValue = self::getConfigSetting($gateway, 'is_offsite');
+        // If the value from config is set, return it
+        if (is_bool($configValue)) {
+            return $configValue;
         }
 
         $factory = new GatewayFactory();

--- a/tests/CreateCardServiceTest.php
+++ b/tests/CreateCardServiceTest.php
@@ -112,21 +112,32 @@ class CreateCardServiceTest extends BasePurchaseServiceTest
         //--------------------------------------------------------------------------------------------------------------
         // Payment request and response
 
-        $mockPaymentResponse = $this->getMockBuilder('Omnipay\Dummy\Message\Response')
-            ->disableOriginalConstructor()->getMock();
+        $mockPaymentResponse = $this
+            ->getMockBuilder('Omnipay\Dummy\Message\Response')
+            ->disableOriginalConstructor()
+            ->setMethods(['isSuccessful'])
+            ->getMock();
 
-        $mockPaymentResponse->expects($this->any())
-            ->method('isSuccessful')->will($this->returnValue($successValue));
+        $mockPaymentResponse
+            ->expects($this->any())
+            ->method('isSuccessful')
+            ->will($this->returnValue($successValue));
 
-        $mockPaymentRequest = $this->getMockBuilder('Omnipay\Dummy\Message\AuthorizeRequest')
-            ->disableOriginalConstructor()->getMock();
+        $mockPaymentRequest = $this
+            ->getMockBuilder('Omnipay\Dummy\Message\AbstractRequest')
+            ->setMethods(['send'])
+            ->getMock();
 
-        $mockPaymentRequest->expects($this->any())->method('send')->will($this->returnValue($mockPaymentResponse));
+        $mockPaymentRequest
+            ->expects($this->any())
+            ->method('send')
+            ->will($this->returnValue($mockPaymentResponse));
 
         //--------------------------------------------------------------------------------------------------------------
         // Build the gateway
 
-        $stubGateway = $this->getMockBuilder('Omnipay\Common\AbstractGateway')
+        $stubGateway = $this
+            ->getMockBuilder('Omnipay\Common\AbstractGateway')
             ->setMethods(array('createCard', 'getName'))
             ->getMock();
 

--- a/tests/GatewayFieldsFactoryTest.php
+++ b/tests/GatewayFieldsFactoryTest.php
@@ -174,37 +174,38 @@ class GatewayFieldsFactoryTest extends SapphireTest
 
     public function testRequiredFields()
     {
-        Config::modify()->merge(GatewayInfo::class, 'Dummy', array(
-            'required_fields' => array(
+        Config::modify()->merge(GatewayInfo::class, 'Dummy', [
+            'required_fields' => [
                 'billingAddress1',
                 'city',
                 'country',
                 'email',
                 'company'
-            )
-        ));
+            ],
+            'is_offsite' => false
+        ]);
 
-        Config::modify()->merge(GatewayInfo::class, 'PayPal_Express', array(
-            'required_fields' => array(
+        Config::modify()->merge(GatewayInfo::class, 'PayPal_Express', [
+            'required_fields' => [
                 'billingAddress1',
                 'city',
                 'country',
                 'email',
                 'company'
-            )
-        ));
+            ]
+        ]);
 
-        $factory = new GatewayFieldsFactory('Dummy', array(
+        $factory = new GatewayFieldsFactory('Dummy', [
             'Card',
             'Billing',
             'Shipping',
             'Company',
             'Email'
-        ));
+        ]);
 
         $fields = $factory->getFields();
 
-        $defaults = array(
+        $defaults = [
             // default required CC fields for gateways that aren't manual and aren't offsite
             'name',
             'number',
@@ -219,23 +220,23 @@ class GatewayFieldsFactoryTest extends SapphireTest
             'shippingCountry',
             'company',
             'email'
-        );
+        ];
 
         $this->assertEquals($this->factory->getFieldName($defaults), array_keys($fields->dataFields()));
 
         // Same procedure with offsite gateway should not return the CC fields
 
-        $factory = new GatewayFieldsFactory('PayPal_Express', array(
+        $factory = new GatewayFieldsFactory('PayPal_Express', [
             'Card',
             'Billing',
             'Shipping',
             'Company',
             'Email'
-        ));
+        ]);
 
         $fields = $factory->getFields();
 
-        $pxDefaults = array(
+        $pxDefaults = [
             'billingAddress1',
             'billingCity',
             'billingCountry',
@@ -243,13 +244,17 @@ class GatewayFieldsFactoryTest extends SapphireTest
             'shippingCountry',
             'company',
             'email'
-        );
+        ];
 
         $this->assertEquals($this->factory->getFieldName($pxDefaults), array_keys($fields->dataFields()));
     }
 
     public function testRenamedFields()
     {
+        Config::modify()->merge(GatewayInfo::class, 'Dummy', [
+            'is_offsite' => false
+        ]);
+
         Config::modify()->merge('SilverStripe\Omnipay\GatewayFieldsFactory', 'rename', array(
             'prefix' => 'prefix_',
             'name' => 'testName',


### PR DESCRIPTION
Fix unit-tests for changes that happened in the Dummy gateway.