### PR TITLE
Removed `use` statement  i18nTestManifest included twice

### DIFF
--- a/tests/GatewayInfoTest.php
+++ b/tests/GatewayInfoTest.php
@@ -17,8 +17,6 @@ use SilverStripe\i18n\Tests\i18nTestManifest;
 
 class GatewayInfoTest extends SapphireTest
 {
-    use i18nTestManifest;
-
     protected function tearDown()
     {
         $this->tearDownManifest();


### PR DESCRIPTION
Removed additional  `use i18nTestManifest` within the GatewayInfoTest.php