### PR TITLE
Support Omnipay v3, as Omnipay v2 hasn't seen active development since 2016

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .php_cs.cache
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,15 @@
     "require": {
         "silverstripe/framework": "^4",
         "silverstripe/config": "^1",
-        "omnipay/common": "^2.4"
+        "omnipay/common": "^3"
     },
     "require-dev": {
         "silverstripe/versioned" : "^1.0",
         "phpunit/phpunit": "^5.7",
-        "guzzle/guzzle": "^3.9",
-        "omnipay/paypal": "^2.5",
-        "omnipay/dummy": "^2.1",
-        "omnipay/paymentexpress": "^2.1"
+        "php-http/guzzle6-adapter": "^1.1",
+        "omnipay/paypal": "^3",
+        "omnipay/dummy": "^3",
+        "omnipay/paymentexpress": "^3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Admin/PaymentDevelopmentAdmin.php
+++ b/src/Admin/PaymentDevelopmentAdmin.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Omnipay\Admin;
 
+use Omnipay\Omnipay;
 use SilverStripe\Dev\Debug;
 use SilverStripe\Omnipay\GatewayInfo;
 use SilverStripe\Control\Controller;
@@ -75,11 +76,11 @@ class PaymentDevelopmentAdmin extends Controller
      */
     private function PaymentTypes()
     {
-        $factory = new \Omnipay\Common\GatewayFactory;
+        $factory = Omnipay::getFactory();
         // since the omnipay gateway factory only returns gateways from the composer.json extra data,
         // we should merge it with user-defined gateways from Payment.allowed_gateways
         $gateways = array_unique(array_merge(
-            $factory->find(),
+            $factory->all(),
             array_keys(GatewayInfo::getSupportedGateways(false))
         ));
 

--- a/src/Extensions/Payable.php
+++ b/src/Extensions/Payable.php
@@ -5,11 +5,13 @@ namespace SilverStripe\Omnipay\Extensions;
 use SilverStripe\Omnipay\GatewayInfo;
 use SilverStripe\Omnipay\Model\Payment;
 use SilverStripe\ORM\DataExtension;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\HasManyList;
 
 /**
  * An extension for providing payments on a particular data object.
  *
+ * @property DataObject|Payable $owner
  * @method Payment[]|HasManyList Payments()
  */
 class Payable extends DataExtension

--- a/src/Extensions/SagePayExtension.php
+++ b/src/Extensions/SagePayExtension.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Omnipay\Extensions;
 
 use Omnipay\SagePay\Message\ServerNotifyResponse;
+use SilverStripe\Omnipay\Model\Message\PurchaseRedirectResponse;
 use SilverStripe\Omnipay\Service\ServiceResponse;
 use SilverStripe\Core\Extension;
 use SilverStripe\Omnipay\Model\Message;
@@ -84,7 +85,7 @@ class SagePayExtension extends Extension
      */
     private function addTransactionReference(array &$gatewayData, $isAuthorize = false)
     {
-        /** @var \Payment $payment */
+        /** @var Payment $payment */
         $payment = $this->owner->getPayment();
 
         // Only apply the changes if the gateway is SagePay Server

--- a/src/Helper/PaymentMath.php
+++ b/src/Helper/PaymentMath.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\Omnipay\Helper;
 
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Config\Configurable;
 
 /**

--- a/src/Model/Payment.php
+++ b/src/Model/Payment.php
@@ -29,6 +29,8 @@ use SilverStripe\Forms\GridField\GridFieldConfig_RecordViewer;
  *
  * @property string $Gateway
  * @property DBMoney $Money
+ * @property string $MoneyCurrency
+ * @property float $MoneyAmount
  * @property string $Status
  * @property string $Identifier
  * @property string $TransactionReference
@@ -178,6 +180,7 @@ final class Payment extends DataObject implements PermissionProvider
     /**
      * Set the url to redirect to after payment is cancelled.
      *
+     * @param string $url URL to redirect to on payment cancellation.
      * @return $this this object for chaining
      */
     public function setFailureUrl($url)
@@ -274,6 +277,7 @@ final class Payment extends DataObject implements PermissionProvider
     /**
      * Set the payment currency, but only when the status is 'Created'.
      * @param string $currency the currency to set
+     * @return $this
      */
     public function setCurrency($currency)
     {

--- a/src/Model/message/GatewayMessage.php
+++ b/src/Model/message/GatewayMessage.php
@@ -2,6 +2,13 @@
 
 namespace SilverStripe\Omnipay\Model\Message;
 
+/**
+ * Class GatewayMessage
+ * @package SilverStripe\Omnipay\Model\Message
+ * @property string $Gateway
+ * @property string $Reference
+ * @property string $Code
+ */
 class GatewayMessage extends PaymentMessage
 {
     private static $db = [

--- a/src/Model/message/PaymentMessage.php
+++ b/src/Model/message/PaymentMessage.php
@@ -9,7 +9,12 @@ use SilverStripe\Omnipay\Model\Payment;
 
 /**
  * Base class for logging messages, transactions etc associated with a payment.
- *
+ * @property string $Message
+ * @property string $ClientIp
+ * @property int $PaymentID
+ * @property int $UserID
+ * @method null|Payment Payment()
+ * @method null|Member Member()
  */
 class PaymentMessage extends DataObject
 {

--- a/src/Service/CaptureService.php
+++ b/src/Service/CaptureService.php
@@ -13,6 +13,7 @@ use SilverStripe\Omnipay\Model\Message\CaptureError;
 use SilverStripe\Omnipay\Model\Message\CaptureRequest;
 use SilverStripe\Omnipay\Model\Message\PartiallyCapturedResponse;
 use SilverStripe\Omnipay\Helper\PaymentMath;
+use SilverStripe\Omnipay\Model\Payment;
 
 /**
  * Service used in tandem with AuthorizeService.
@@ -169,6 +170,7 @@ class CaptureService extends NotificationCompleteService
         if ($partials->count() > 0) {
             $i = 0;
             $total = $originalTotal = $this->payment->MoneyAmount;
+            /** @var Payment $payment */
             foreach ($partials as $payment) {
                 // only the first, eg. most recent payment should be considered valid. All others should be set to void
                 if ($i === 0) {

--- a/src/Service/CreateCardService.php
+++ b/src/Service/CreateCardService.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\Omnipay\Service;
 
+use Omnipay\Common\Message\RequestInterface;
 use SilverStripe\Omnipay\Exception\InvalidStateException;
 use SilverStripe\Omnipay\Exception\InvalidConfigurationException;
 use SilverStripe\Omnipay\Helper\ErrorHandling;
@@ -98,6 +99,7 @@ class CreateCardService extends PaymentService
         $gatewayData = $this->gatherGatewayData($data);
 
         $this->extend('onBeforeCompleteCreateCard', $gatewayData);
+        /** @var RequestInterface $request */
         $request = $gateway->completeCreateCard($gatewayData);
         $this->extend('onAfterCompleteCreateCard', $request);
 

--- a/src/Service/NotificationCompleteService.php
+++ b/src/Service/NotificationCompleteService.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Omnipay\Service;
 
 use SilverStripe\Omnipay\Exception\InvalidStateException;
 use SilverStripe\Omnipay\Exception\InvalidConfigurationException;
+use SilverStripe\Omnipay\Model\Payment;
 
 /**
  * Abstract base class for payment services that operate on an existing transaction. Examples of this are:
@@ -103,6 +104,7 @@ abstract class NotificationCompleteService extends PaymentService
         // void any pending partial payments
         $pending = $this->payment->getPartialPayments()->filter('Status', $this->pendingState);
 
+        /** @var Payment $payment */
         foreach ($pending as $payment) {
             $payment->Status = 'Void';
             $payment->write();

--- a/src/Service/RefundService.php
+++ b/src/Service/RefundService.php
@@ -10,6 +10,7 @@ use SilverStripe\Omnipay\GatewayInfo;
 use SilverStripe\Omnipay\Helper\ErrorHandling;
 use SilverStripe\Omnipay\Helper\PaymentMath;
 use SilverStripe\Omnipay\Model\Message;
+use SilverStripe\Omnipay\Model\Payment;
 
 class RefundService extends NotificationCompleteService
 {
@@ -154,6 +155,7 @@ class RefundService extends NotificationCompleteService
         if ($partials->count() > 0) {
             $i = 0;
             $total = $this->payment->MoneyAmount;
+            /** @var Payment $payment */
             foreach ($partials as $payment) {
                 // only the first, eg. most recent payment should be considered valid. All others should be set to void
                 if ($i === 0) {

--- a/tests/Service/TestGatewayFactory.php
+++ b/tests/Service/TestGatewayFactory.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\Omnipay\Tests\Service;
 
-use Guzzle\Http\ClientInterface;
 use Omnipay\Common\GatewayFactory;
+use Omnipay\Common\Http\ClientInterface;
 use SilverStripe\Dev\TestOnly;
 use Symfony\Component\HttpFoundation\Request as HttpRequest;
 


### PR DESCRIPTION
There is minimal user exposed change in the API. Majority of change is in how gateways internally handle sending requests (via `ClientInterface`, rather than an explicit dependency on Guzzle).

Unfortunately, there is currently a failing test due to a stray reference to Guzzle in the `omnipay/paymentexpress` gateway package. All tests pass once this is resolved - thephpleague/omnipay-paymentexpress#50, thephpleague/omnipay-paymentexpress#51

Resolves #196 