### PR TITLE
Make payment identifier length configurable - globally / per gateway

### DIFF
--- a/src/Model/Payment.php
+++ b/src/Model/Payment.php
@@ -76,7 +76,10 @@ final class Payment extends DataObject implements PermissionProvider
     ];
 
     private static $indexes = [
-        'Identifier' => true,
+        'Identifier' => [
+            'type' => 'unique',
+            'columns' => ['Identifier'],
+        ],
     ];
 
     private static $table_name = 'Omnipay_Payment';

--- a/src/Model/Payment.php
+++ b/src/Model/Payment.php
@@ -561,11 +561,12 @@ final class Payment extends DataObject implements PermissionProvider
      */
     protected function generateUniquePaymentIdentifier()
     {
-        $generator = Injector::inst()->create(RandomGenerator::class);
+        $generator = Injector::inst()->get(RandomGenerator::class);
         $id = null;
+
         do {
             $id = substr($generator->randomToken(), 0, 30);
-        } while (!$id && self::get()->filter('Identifier', $id)->exists());
+        } while (empty($id) || self::get()->filter('Identifier', $id)->exists());
 
         return $id;
     }

--- a/tests/PaymentModelTest.php
+++ b/tests/PaymentModelTest.php
@@ -2,13 +2,11 @@
 
 namespace SilverStripe\Omnipay\Tests;
 
-use Omnipay\Dummy\Gateway;
-use SilverStripe\Core\Injector\Injector;
-use SilverStripe\i18n\Messages\MessageProvider;
-use SilverStripe\Omnipay\Model\Payment;
-use SilverStripe\Omnipay\GatewayInfo;
 use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\i18n\i18n;
+use SilverStripe\Omnipay\GatewayInfo;
+use SilverStripe\Omnipay\Model\Payment;
 use SilverStripe\Omnipay\Tests\Service\TestRandomGenerator;
 use SilverStripe\Security\RandomGenerator;
 
@@ -326,5 +324,30 @@ class PaymentModelTest extends PaymentTest
         $payment2 = Payment::create();
         $payment2->write();
         $this->assertSame('token2', $payment2->Identifier);
+    }
+
+    /**
+     *
+     */
+    public function testIdentifierLengthConfig()
+    {
+        Config::modify()->set(Payment::class, 'payment_identifier_length', 20);
+        $payment = Payment::create();
+        $payment->write();
+        $this->assertSame(20, strlen($payment->Identifier));
+
+        Config::modify()->set(Payment::class, 'payment_identifier_length', 30);
+        $payment = Payment::create();
+        $payment->setGateway('Manual');
+        $payment->write();
+        $this->assertSame(30, strlen($payment->Identifier));
+
+        Config::modify()->merge(GatewayInfo::class, 'IdentifierFifteen', [
+            'payment_identifier_length' => 15,
+        ]);
+        $payment = Payment::create();
+        $payment->setGateway('IdentifierFifteen');
+        $payment->write();
+        $this->assertSame(15, strlen($payment->Identifier));
     }
 }

--- a/tests/PaymentModelTest.php
+++ b/tests/PaymentModelTest.php
@@ -9,6 +9,8 @@ use SilverStripe\Omnipay\Model\Payment;
 use SilverStripe\Omnipay\GatewayInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\i18n\i18n;
+use SilverStripe\Omnipay\Tests\Service\TestRandomGenerator;
+use SilverStripe\Security\RandomGenerator;
 
 class PaymentModelTest extends PaymentTest
 {
@@ -306,5 +308,23 @@ class PaymentModelTest extends PaymentTest
         $payment->init('Dummy', '1.19', 'EUR');
         $payment->Status = 'Authorized';
         $this->assertEquals('1.42', $payment->getMaxCaptureAmount());
+    }
+
+    /**
+     *
+     */
+    public function testDuplicateIdentifiers()
+    {
+        $randomGenerator = new TestRandomGenerator();
+        $randomGenerator->addRandomTokens('token1', 'token1', 'token1', 'token2');
+        Injector::inst()->registerService($randomGenerator, RandomGenerator::class);
+
+        $payment1 = Payment::create();
+        $payment1->write();
+        $this->assertSame('token1', $payment1->Identifier);
+
+        $payment2 = Payment::create();
+        $payment2->write();
+        $this->assertSame('token2', $payment2->Identifier);
     }
 }

--- a/tests/Service/TestRandomGenerator.php
+++ b/tests/Service/TestRandomGenerator.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SilverStripe\Omnipay\Tests\Service;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Security\RandomGenerator;
+
+/**
+ * Class TestRandomGenerator
+ * @package SilverStripe\Omnipay\Tests\Service
+ */
+class TestRandomGenerator extends RandomGenerator implements TestOnly
+{
+    /**
+     * @var array
+     */
+    protected $entropy = [];
+
+    /**
+     * @var array
+     */
+    protected $randomToken = [];
+
+    /**
+     * @param string ...$values
+     */
+    public function addEntropy(...$values)
+    {
+        $this->entropy = array_merge($this->entropy, $values);
+    }
+
+    /**
+     * @param string ...$tokens
+     */
+    public function addRandomTokens(...$tokens)
+    {
+        $this->randomToken = array_merge($this->randomToken, $tokens);
+    }
+
+    /**
+     * @return string
+     * @throws \Exception
+     */
+    public function generateEntropy()
+    {
+        if (!empty($this->entropy)) {
+            return array_shift($this->entropy);
+        }
+
+        return parent::generateEntropy();
+    }
+
+    /**
+     * @param string $algorithm
+     * @return string
+     */
+    public function randomToken($algorithm = 'whirlpool')
+    {
+        if (!empty($this->randomToken)) {
+            return array_shift($this->randomToken);
+        }
+
+        return parent::randomToken($algorithm);
+    }
+}


### PR DESCRIPTION
- Resolves #142
- Fixes bug in generation that allowed duplicate identifiers
- Adds tests for the above two points
- Adds unique index to `Identifier` column to prevent future issues