### PR TITLE
prevent death on singletons & summary fields

### DIFF
--- a/src/Model/Payment.php
+++ b/src/Model/Payment.php
@@ -248,7 +248,10 @@ final class Payment extends DataObject implements PermissionProvider
      */
     public function getPaymentStatus()
     {
-        return _t('SilverStripe\Omnipay\Model\Payment.STATUS_' . strtoupper($this->Status), $this->Status);
+        if ($this->Status) {
+            return _t('SilverStripe\Omnipay\Model\Payment.STATUS_' . strtoupper($this->Status), $this->Status);
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
can't send a null/empty value for localisation