### PR TITLE
PaymentForm is not an OmniPay class

### DIFF
--- a/.upgrade.yml
+++ b/.upgrade.yml
@@ -1,6 +1,4 @@
 mappings:
-  PaymentForm: SilverStripe\Omnipay\PaymentForm
-
   Payable: SilverStripe\Omnipay\Extensions\Payable
   Payment: SilverStripe\Omnipay\Model\Payment
   PaymentMessage: SilverStripe\Omnipay\Model\Message\PaymentMessage


### PR DESCRIPTION
The silvershop/core module defines a `PaymentForm` class ([source](https://github.com/silvershop/silvershop-core/blob/master/src/Forms/PaymentForm.php)), but this module doesn't.

Having this class listed here means that the Silverstripe 4 upgrader tool complains about it: `Config option PaymentForm is defined with different values in multiple files`