### PR TITLE
Removing duplicate entry from config

### DIFF
--- a/_config/legacy.yml
+++ b/_config/legacy.yml
@@ -6,7 +6,6 @@ SilverStripe\ORM\DatabaseAdmin:
   classname_value_remapping:
     Payment: SilverStripe\Omnipay\Model\Payment
     PaymentMessage: SilverStripe\Omnipay\Model\Message\PaymentMessage
-    GatewayRequestMessage: SilverStripe\Omnipay\Model\Message\GatewayRequestMessage
     AuthorizedResponse: SilverStripe\Omnipay\Model\Message\AuthorizedResponse
     AuthorizeError: SilverStripe\Omnipay\Model\Message\AuthorizeError
     AuthorizeRedirectResponse: SilverStripe\Omnipay\Model\Message\AuthorizeRedirectResponse


### PR DESCRIPTION
PHP Deprecated: Duplicate key "GatewayRequestMessage" detected whilst parsing YAML. Silent handling of duplicate mapping keys in YAML is deprecated since Symfony 3.2 and will throw \Symfony\Component\Yaml\Exception\ParseException in 4.0