### PR TITLE
NEW: Allow logging exceptions separately to non-fatal errors (fixes #226)

### DIFF
--- a/_config/logging.yml
+++ b/_config/logging.yml
@@ -4,6 +4,7 @@ Name: omnipay-logging
 # Set up a separate logger name for omnipay, but map it to the default implementation
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Omnipay\Logger: '%$Psr\Log\LoggerInterface'
+  SilverStripe\Omnipay\ExceptionLogger: '%$SilverStripe\Omnipay\Logger'
 
 # Example how to set up a logger for omnipay that logs to a separate log-file named "omnipay.log"
 # SilverStripe\Core\Injector\Injector:

--- a/docs/en/Logging.md
+++ b/docs/en/Logging.md
@@ -1,9 +1,9 @@
 # Logging
 
-This module uses standard SilverStripe logging (via [monolog](https://github.com/Seldaek/monolog)). 
+This module uses standard SilverStripe logging (via [monolog](https://github.com/Seldaek/monolog)).
 Please read the [SilverStripe logging documentation](https://docs.silverstripe.org/en/4/developer_guides/debugging/error_handling/) on how to set up basic logging.
 
-By default, the Omnipay module logs to the default logger of SilverStripe. 
+By default, the Omnipay module logs to the default logger of SilverStripe.
 If you'd like, you can create a custom Log for Omnipay though (even with a custom error-level).
 
 Here's an example config that configures a separate log output for SilverStripe, as well as one for Omnipay:
@@ -49,7 +49,7 @@ There's a config setting `SilverStripe\Omnipay\Helper\Logging.logStyle` that def
 - `'verbose'`: Verbose logging, but strips out sensitive information
 - `'simple'`: Simplified messages (only title, message and code)
 
-There's also a setting that controls which data-fields will be sanitized, so that they don't show up in the logs. If you're logging on 
+There's also a setting that controls which data-fields will be sanitized, so that they don't show up in the logs. If you're logging on
 a live environment, make sure to NOT log any sensitive information, such as credit-card numbers and CVV numbers!
 
 You can control this "blacklist" via the `SilverStripe\Omnipay\Helper\Logging.loggingBlacklist` setting. By default the Helper class is configured like this:
@@ -61,4 +61,21 @@ SilverStripe\Omnipay\Helper\Logging:
     - 'card'
     - 'token'
     - 'cvv'
+```
+
+## Disable non-fatal error logging
+
+In production environments, it is often desirable to disable logging anything that isn't an application error. This can be achieved
+by disabling the default `SilverStripe\Omnipay\Logger` logger instance, and adding a new logger for logging exceptions:
+
+```yml
+---
+Name: payment-logging
+After:
+  - '#omnipay-logging'
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\Omnipay\Logger:
+    class: 'Psr\Log\NullLogger'
+  SilverStripe\Omnipay\ExceptionLogger: '%$Psr\Log\LoggerInterface'
 ```

--- a/src/Service/PaymentService.php
+++ b/src/Service/PaymentService.php
@@ -34,6 +34,7 @@ use SilverStripe\Omnipay\PaymentGatewayController;
  *
  * Interfaces with the omnipay library.
  * @property LoggerInterface $logger
+ * @property LoggerInterface $exceptionLogger
  */
 abstract class PaymentService
 {
@@ -45,6 +46,7 @@ abstract class PaymentService
      */
     private static $dependencies = [
         'logger' => '%$SilverStripe\Omnipay\Logger',
+        'exceptionLogger' => '%$SilverStripe\Omnipay\ExceptionLogger',
     ];
 
     /**
@@ -449,7 +451,11 @@ abstract class PaymentService
             'Gateway' => $this->payment->Gateway
         ]);
 
-        $this->logToFile($output, $type);
+        if ($data instanceof \Exception) {
+            $this->exceptionLogger->error($e->getMessage(), ['exception' => $e]);
+        } else {
+            $this->logToFile($output, $type);
+        }
 
         /** @var PaymentMessage $message */
         $message = Injector::inst()->create($type)->update($output);


### PR DESCRIPTION
Fixes #226. It’s currently not possible to disable the `logToFile()` method without also disabling logging any exceptions which arise, which is obviously not great as they’ll then go un-reported.

This should be backward compatible, as the new `exceptionLogger` will just default to using the existing `SilverStripe\Omnipay\Logger` service config.