### PR TITLE
Fix issue where exceptions triggered by extensions could be silently swallowed

### DIFF
--- a/src/Helper/ErrorHandling.php
+++ b/src/Helper/ErrorHandling.php
@@ -51,7 +51,7 @@ class ErrorHandling
         try {
             $retVal = $object->extend($method, $a1, $a2, $a3, $a4, $a5, $a6, $a7);
         } catch (\Exception $ex) {
-            if ($logger = Logging::getLogger()) {
+            if ($logger = Logging::getExceptionLogger()) {
                 $logger->warning(
                     'An error occurred when trying to run extension point: '. $object->class . '->' . $method,
                     [
@@ -89,7 +89,7 @@ class ErrorHandling
             restore_error_handler();
             return $retVal;
         } catch (\Exception $ex) {
-            if ($logger = Logging::getLogger()) {
+            if ($logger = Logging::getExceptionLogger()) {
                 $logger->warning($errorMessage, [
                     'exception' => $ex
                 ]);

--- a/src/Helper/Logging.php
+++ b/src/Helper/Logging.php
@@ -50,6 +50,20 @@ class Logging
     }
 
     /**
+     * @return \Psr\Log\LoggerInterface
+     */
+    public static function getExceptionLogger()
+    {
+        $logger = null;
+        try {
+            $logger = Injector::inst()->get('SilverStripe\Omnipay\ExceptionLogger');
+        } catch (NotFoundExceptionInterface $e) {
+            /* no op */
+        }
+        return $logger;
+    }
+
+    /**
      * Prepare data for logging by cleaning up the data or simplify it.
      * @param mixed $data the incoming data to log
      * @return array processed data for logging


### PR DESCRIPTION
Something I overlooked in https://github.com/silverstripe/silverstripe-omnipay/pull/229. `Logging::getLogger()` uses the default logging service, `SilverStripe\Omnipay\Logger`. If that has been set to a `NullLogger` as per the instructions in added #229, then exceptions thrown during `safeExtend()` can be swallowed in live mode.

This change ensures that if a separate logger is set up for fatal errors (as described in #229), it will be used by `safeExtend()` and `safeguard()` so that exceptions can still be logged. As per the other pull request, if no separate Injector service has been set up for `SilverStripe\Omnipay\ExceptionLogger` then it inherits from `SilverStripe\Omnipay\Logger` instead: 
https://github.com/silverstripe/silverstripe-omnipay/blob/a44ee690f30ab2ab1da4834fecb1b6b7d91ff79b/_config/logging.yml#L7

I’ve pushed a 3.1 branch for this, so it can be tagged as 3.1.2 without including the other changes that are currently in master.