### PR TITLE
Anonymous recursive function requires use () to work & changed var passed into it to avoid infinite loop

### DIFF
--- a/src/GatewayInfo.php
+++ b/src/GatewayInfo.php
@@ -442,10 +442,10 @@ class GatewayInfo
             return null;
         }
 
-        $convertConstants = function(&$config) {
+        $convertConstants = function(&$config) use (&$convertConstants){
             foreach ($config as $key => &$value) {
                 if (is_array($value)) {
-                    $convertConstants($config);
+                    $convertConstants($value);
                     continue;
                 }
 


### PR DESCRIPTION
Hey,

Previously it'd fail with "ERROR [User Error]: Uncaught Error: Function name must be a string", use (&$convertConstants) must be used for anonymous recursive functions ( https://stackoverflow.com/a/2480242 )

Also the value passed in recursively is $config, which makes it an infinite loop. I changed this to be $value instead which makes it work.


Tom
